### PR TITLE
Recolor settings page with vibrant accent palette

### DIFF
--- a/src/routes/HomePage.tsx
+++ b/src/routes/HomePage.tsx
@@ -24,12 +24,56 @@ export const HomePage = () => {
   return (
     <div className="fade-in">
       <section className={`glass-card ${styles.hero}`}>
-        <div>
-          <p className={styles.welcome}>你好，{profile.name}</p>
-          <h2>累计积分 {stats.totalScore}</h2>
-          <p>
-            共完成 <strong>{stats.totalPlays}</strong> 场挑战，最佳连击 <strong>{stats.bestCombo}</strong>。
-          </p>
+        <div className={styles.heroMain}>
+          <div>
+            <p className={styles.welcome}>你好，{profile.name}</p>
+            <h2>累计积分 {stats.totalScore}</h2>
+            <p>
+              共完成 <strong>{stats.totalPlays}</strong> 场挑战，最佳连击 <strong>{stats.bestCombo}</strong>。
+            </p>
+          </div>
+
+          <div className={styles.heroSummary}>
+            <div className={styles.progressBlock}>
+              <div className={styles.progressHeader}>
+                <span>关卡探索进度</span>
+                <strong>
+                  {LEVELS.length ? Math.round((Math.min(progress.length, LEVELS.length) / LEVELS.length) * 100) : 0}%
+                </strong>
+              </div>
+              <div className={styles.progressBar}>
+                <div
+                  className={styles.progressFill}
+                  style={{
+                    width: `${LEVELS.length ? (Math.min(progress.length, LEVELS.length) / LEVELS.length) * 100 : 0}%`
+                  }}
+                />
+              </div>
+              <p className={styles.progressHint}>
+                已解锁 <strong>{progress.length}</strong> / {LEVELS.length} 个关卡
+              </p>
+            </div>
+            <div className={styles.statHighlights}>
+              <div className={styles.statChip}>
+                <span>平均正确率</span>
+                <strong>
+                  {stats.totalCorrect + stats.totalWrong
+                    ? Math.round((stats.totalCorrect / (stats.totalCorrect + stats.totalWrong)) * 100)
+                    : 0}
+                  %
+                </strong>
+              </div>
+              <div className={styles.statChip}>
+                <span>总答题数</span>
+                <strong>{stats.totalCorrect + stats.totalWrong}</strong>
+              </div>
+              <div className={styles.statChip}>
+                <span>累计时长</span>
+                <strong>{Math.round(stats.totalTimeSec / 60)} 分钟</strong>
+              </div>
+            </div>
+          </div>
+
           <div className={styles.actions}>
             <button className="btn" onClick={() => navigate('/levels')}>
               🚀 开始挑战
@@ -44,22 +88,36 @@ export const HomePage = () => {
             </button>
           </div>
         </div>
-        <div className={styles.badges}>
-          <div>
-            <span className="tag">创建于</span>
-            <p>{formatDate(profile.createdAt)}</p>
+        <div className={styles.heroAside}>
+          <div className={styles.badgeCard}>
+            <span className="tag">加入勇者团</span>
+            <p className={styles.badgeValue}>{formatDate(profile.createdAt)}</p>
+            <small>保持每日训练，打造最强心算力！</small>
           </div>
           {bestScore ? (
-            <div>
-              <span className="tag">最高分</span>
-              <p>
-                {bestScore.bestScore} 分 @ {bestScore.levelId}
-              </p>
+            <div className={styles.badgeCard}>
+              <span className="tag">最高得分记录</span>
+              <p className={styles.badgeValue}>{bestScore.bestScore} 分</p>
+              <small>来自关卡 {bestScore.levelId}</small>
             </div>
           ) : (
-            <div>
+            <div className={styles.badgeCard}>
               <span className="tag">新冒险者</span>
-              <p>快去挑战第一个关卡吧！</p>
+              <p className={styles.badgeValue}>探索从现在开始</p>
+              <small>试试基础关卡热热身 🔥</small>
+            </div>
+          )}
+          {lastLevel ? (
+            <div className={`${styles.badgeCard} ${styles.nextChallenge}`}>
+              <span className="tag">下一个目标</span>
+              <p className={styles.badgeValue}>{lastLevel.name}</p>
+              <small>{lastLevel.desc}</small>
+            </div>
+          ) : (
+            <div className={`${styles.badgeCard} ${styles.nextChallenge}`}>
+              <span className="tag">今日建议</span>
+              <p className={styles.badgeValue}>完成首个挑战</p>
+              <small>任选一个关卡开启旅程 ✨</small>
             </div>
           )}
         </div>

--- a/src/routes/PlayPage.tsx
+++ b/src/routes/PlayPage.tsx
@@ -40,6 +40,28 @@ export const PlayPage = () => {
   const [encouragingMsg, setEncouragingMsg] = useState('');
   const playSound = useFeedbackSound(settings.audio);
 
+  const handleNumberClick = useCallback(
+    (num: string) => {
+      if (state !== 'playing') return;
+      setAnswer((prev) => prev + num);
+    },
+    [state]
+  );
+
+  const handleDelete = useCallback(() => {
+    setAnswer((prev) => prev.slice(0, -1));
+  }, []);
+
+  const handleClear = useCallback(() => {
+    setAnswer('');
+  }, []);
+
+  const handleSubmit = useCallback(() => {
+    if (!answer.trim() || state !== 'playing') return;
+    Game.submit(answer);
+    setFeedback(null);
+  }, [answer, state]);
+
   useEffect(() => {
     if (!level) {
       setError('未找到关卡，返回关卡列表');
@@ -142,7 +164,7 @@ export const PlayPage = () => {
       unsubFinish();
       Game.reset();
     };
-  }, [level, navigate, playSound, recordResult, setLastResult, state, answer, handleNumberClick, handleSubmit, handleDelete, handleClear]);
+  }, [level, navigate, playSound, recordResult, setLastResult, handleNumberClick, handleSubmit, handleDelete, handleClear]);
 
   if (!level) {
     return (
@@ -157,29 +179,8 @@ export const PlayPage = () => {
 
   const onSubmit = (evt: FormEvent) => {
     evt.preventDefault();
-    if (!answer.trim() || state !== 'playing') return;
-    Game.submit(answer);
-    setFeedback(null);
+    handleSubmit();
   };
-
-  const handleNumberClick = useCallback((num: string) => {
-    if (state !== 'playing') return;
-    setAnswer((prev) => prev + num);
-  }, [state]);
-
-  const handleDelete = useCallback(() => {
-    setAnswer((prev) => prev.slice(0, -1));
-  }, []);
-
-  const handleClear = useCallback(() => {
-    setAnswer('');
-  }, []);
-
-  const handleSubmit = useCallback(() => {
-    if (!answer.trim() || state !== 'playing') return;
-    Game.submit(answer);
-    setFeedback(null);
-  }, [answer, state]);
 
   const handleExit = useCallback(() => {
     if (showExitConfirm) {
@@ -353,12 +354,21 @@ export const PlayPage = () => {
               <div className={styles.statItem}>
                 <span className={styles.statLabel}>正确率</span>
                 <span className={styles.statValue}>
-                  {snapshot ? Math.round((snapshot.correctCount / Math.max(1, snapshot.questionIndex)) * 100) : 0}%
+                  {snapshot && snapshot.questionIndex > 0
+                    ? Math.round((snapshot.correct / snapshot.questionIndex) * 100)
+                    : snapshot?.correct
+                    ? 100
+                    : 0}
+                  %
                 </span>
               </div>
               <div className={styles.statItem}>
-                <span className={styles.statLabel}>当前得分</span>
-                <span className={styles.statValue}>{snapshot?.score ?? 0}</span>
+                <span className={styles.statLabel}>当前连击</span>
+                <span className={styles.statValue}>{snapshot?.combo ?? 0}</span>
+              </div>
+              <div className={styles.statItem}>
+                <span className={styles.statLabel}>最高连击</span>
+                <span className={styles.statValue}>{snapshot?.maxCombo ?? 0}</span>
               </div>
             </div>
           </div>

--- a/src/routes/SettingsPage.tsx
+++ b/src/routes/SettingsPage.tsx
@@ -13,11 +13,16 @@ export const SettingsPage = () => {
   };
 
   return (
-    <div className="fade-in">
-      <section className={`glass-card ${styles.card}`}>
-        <h3>👤 玩家档案</h3>
+    <div className={`fade-in ${styles.wrapper}`}>
+      <section className={`glass-card ${styles.profileCard}`}>
+        <header className={styles.cardHeader}>
+          <div>
+            <h3>👤 玩家档案</h3>
+            <p>为勇士起一个响亮的名字吧，排行榜上更易被识别。</p>
+          </div>
+        </header>
         <form className={styles.form} onSubmit={onSubmit}>
-          <label>
+          <label className={styles.inputRow}>
             <span>昵称</span>
             <input value={name} onChange={(evt) => setName(evt.target.value)} placeholder="输入你的勇士昵称" />
           </label>
@@ -27,43 +32,72 @@ export const SettingsPage = () => {
         </form>
       </section>
 
-      <section className={`glass-card ${styles.card}`}>
-        <h3>🎛️ 游戏偏好</h3>
+      <section className={`glass-card ${styles.preferenceCard}`}>
+        <header className={styles.cardHeader}>
+          <div>
+            <h3>🎛️ 游戏偏好</h3>
+            <p>根据自己的习惯调整体验，保持专注与沉浸感。</p>
+          </div>
+        </header>
         <div className={styles.toggles}>
           <label className={styles.toggleRow}>
-            <span>音效反馈</span>
-            <input
-              type="checkbox"
-              checked={settings.audio}
-              onChange={(evt) => updateSettings({ audio: evt.target.checked })}
-            />
+            <div>
+              <strong>音效反馈</strong>
+              <p>解题时播放提示音，强化节奏感。</p>
+            </div>
+            <div className={styles.switch}>
+              <input
+                type="checkbox"
+                checked={settings.audio}
+                onChange={(evt) => updateSettings({ audio: evt.target.checked })}
+              />
+              <span />
+            </div>
           </label>
           <label className={styles.toggleRow}>
-            <span>震动动画</span>
-            <input
-              type="checkbox"
-              checked={settings.shake}
-              onChange={(evt) => updateSettings({ shake: evt.target.checked })}
-            />
+            <div>
+              <strong>震动动画</strong>
+              <p>答错时轻微震动提醒，增强反馈。</p>
+            </div>
+            <div className={styles.switch}>
+              <input
+                type="checkbox"
+                checked={settings.shake}
+                onChange={(evt) => updateSettings({ shake: evt.target.checked })}
+              />
+              <span />
+            </div>
           </label>
           <label className={styles.toggleRow}>
-            <span>色盲模式</span>
-            <input
-              type="checkbox"
-              checked={settings.colorblind}
-              onChange={(evt) => updateSettings({ colorblind: evt.target.checked })}
-            />
+            <div>
+              <strong>色盲模式</strong>
+              <p>启用高对比配色，让信息更易识别。</p>
+            </div>
+            <div className={styles.switch}>
+              <input
+                type="checkbox"
+                checked={settings.colorblind}
+                onChange={(evt) => updateSettings({ colorblind: evt.target.checked })}
+              />
+              <span />
+            </div>
           </label>
-          <label className={styles.toggleRow}>
-            <span>字体缩放</span>
-            <input
-              type="range"
-              min={0.8}
-              max={1.4}
-              step={0.1}
-              value={settings.fontScale}
-              onChange={(evt) => updateSettings({ fontScale: Number(evt.target.value) })}
-            />
+          <label className={`${styles.toggleRow} ${styles.sliderRow}`}>
+            <div>
+              <strong>字体缩放</strong>
+              <p>调节界面文字大小，保护视力。</p>
+            </div>
+            <div className={styles.rangeControl}>
+              <input
+                type="range"
+                min={0.8}
+                max={1.4}
+                step={0.1}
+                value={settings.fontScale}
+                onChange={(evt) => updateSettings({ fontScale: Number(evt.target.value) })}
+              />
+              <span>{settings.fontScale.toFixed(1)}x</span>
+            </div>
           </label>
         </div>
       </section>

--- a/src/styles/HomePage.module.css
+++ b/src/styles/HomePage.module.css
@@ -1,10 +1,15 @@
 .hero {
   display: grid;
-  grid-template-columns: 1.5fr 1fr;
+  grid-template-columns: minmax(0, 1.5fr) minmax(0, 1fr);
   gap: 40px;
-  align-items: center;
+  align-items: stretch;
   overflow: visible;
   padding: 32px;
+}
+
+.heroMain {
+  display: grid;
+  gap: 28px;
 }
 
 .welcome {
@@ -30,25 +35,128 @@
   line-height: 1.6;
 }
 
+.heroSummary {
+  display: grid;
+  gap: 20px;
+  padding: 20px;
+  border-radius: 18px;
+  background: rgba(249, 115, 22, 0.12);
+  border: 1px solid rgba(249, 115, 22, 0.25);
+  backdrop-filter: blur(12px);
+}
+
+.progressBlock {
+  display: grid;
+  gap: 14px;
+}
+
+.progressHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  color: #9a3412;
+  font-weight: 600;
+}
+
+.progressHeader strong {
+  font-size: 1.4rem;
+}
+
+.progressBar {
+  position: relative;
+  height: 12px;
+  border-radius: 999px;
+  background: rgba(248, 113, 113, 0.25);
+  overflow: hidden;
+}
+
+.progressFill {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, #f97316, #fb923c, #fbbf24);
+  border-radius: inherit;
+  transition: width 0.4s ease;
+}
+
+.progressHint {
+  color: rgba(124, 45, 18, 0.9);
+  font-size: 0.9rem;
+}
+
+.statHighlights {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.statChip {
+  padding: 14px 16px;
+  border-radius: 14px;
+  background: rgba(255, 247, 237, 0.7);
+  border: 1px solid rgba(249, 115, 22, 0.25);
+  display: grid;
+  gap: 6px;
+  color: #c2410c;
+  text-align: left;
+}
+
+.statChip span {
+  font-size: 0.85rem;
+  opacity: 0.8;
+}
+
+.statChip strong {
+  font-size: 1.1rem;
+}
+
 .actions {
-  margin-top: 24px;
+  margin-top: 8px;
   display: flex;
   flex-wrap: wrap;
   gap: 14px;
 }
 
-.badges {
+.heroAside {
   display: grid;
-  gap: 20px;
-  color: #9a3412;
-  font-weight: 500;
+  gap: 18px;
 }
 
-.badges > div {
-  padding: 20px;
-  border-radius: 16px;
-  background: rgba(251, 146, 60, 0.15);
-  border: 2px solid rgba(249, 115, 22, 0.25);
+.badgeCard {
+  padding: 22px 20px;
+  border-radius: 18px;
+  background: linear-gradient(135deg, rgba(251, 146, 60, 0.2), rgba(253, 186, 116, 0.12));
+  border: 1px solid rgba(249, 115, 22, 0.35);
+  color: #9a3412;
+  display: grid;
+  gap: 10px;
+  position: relative;
+  overflow: hidden;
+}
+
+.badgeCard::after {
+  content: '';
+  position: absolute;
+  inset: auto -40% -70% auto;
+  width: 140px;
+  height: 140px;
+  background: radial-gradient(circle at center, rgba(251, 191, 36, 0.4), transparent 70%);
+  transform: rotate(15deg);
+  pointer-events: none;
+}
+
+.badgeValue {
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: #7c2d12;
+}
+
+.badgeCard small {
+  color: rgba(124, 45, 18, 0.75);
+}
+
+.nextChallenge {
+  background: linear-gradient(135deg, rgba(190, 242, 100, 0.25), rgba(147, 197, 253, 0.2));
+  border-color: rgba(59, 130, 246, 0.3);
 }
 
 .sectionHeader {
@@ -148,6 +256,10 @@
 
   .hero h2 {
     font-size: 2.2rem;
+  }
+
+  .heroSummary {
+    padding: 18px;
   }
 
   .levelList {

--- a/src/styles/SettingsPage.module.css
+++ b/src/styles/SettingsPage.module.css
@@ -1,49 +1,175 @@
-.card {
+.wrapper {
   display: grid;
-  gap: 20px;
+  gap: 28px;
+}
+
+.profileCard,
+.preferenceCard {
+  display: grid;
+  gap: 24px;
+  padding: 28px 32px;
+}
+
+.cardHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+}
+
+.cardHeader h3 {
+  font-size: 1.6rem;
+  font-weight: 700;
+  margin-bottom: 6px;
+}
+
+.cardHeader p {
+  color: rgba(125, 211, 252, 0.9);
+  font-size: 0.95rem;
 }
 
 .form {
   display: grid;
-  gap: 16px;
+  gap: 18px;
 }
 
-.form label {
+.inputRow {
   display: grid;
-  gap: 8px;
+  gap: 10px;
+  color: rgba(196, 181, 253, 0.9);
   font-size: 0.95rem;
-  color: rgba(148, 163, 184, 0.8);
 }
 
-.form input {
-  padding: 12px 14px;
-  border-radius: 12px;
-  border: 1px solid rgba(148, 163, 184, 0.35);
-  background: rgba(15, 23, 42, 0.6);
-  color: #f8fafc;
+.inputRow input {
+  padding: 14px 16px;
+  border-radius: 14px;
+  border: 1px solid rgba(56, 189, 248, 0.45);
+  background: rgba(17, 24, 39, 0.65);
+  color: #e0f2fe;
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
 }
 
-.form input:focus {
+.inputRow input:focus {
   outline: none;
-  border-color: rgba(59, 130, 246, 0.6);
-  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.2);
+  border-color: rgba(129, 140, 248, 0.9);
+  box-shadow: 0 14px 34px rgba(129, 140, 248, 0.25);
 }
 
 .toggles {
   display: grid;
-  gap: 16px;
+  gap: 20px;
 }
 
 .toggleRow {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 14px 12px;
-  border-radius: 12px;
-  border: 1px solid rgba(148, 163, 184, 0.2);
-  background: rgba(15, 23, 42, 0.45);
+  gap: 24px;
+  padding: 18px 20px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, rgba(30, 64, 175, 0.55), rgba(45, 212, 191, 0.35));
+  border: 1px solid rgba(129, 140, 248, 0.45);
+  transition: border-color 0.3s ease, transform 0.3s ease, box-shadow 0.3s ease;
 }
 
-.toggleRow span {
-  color: rgba(226, 232, 240, 0.85);
+.toggleRow:hover {
+  border-color: rgba(45, 212, 191, 0.8);
+  box-shadow: 0 18px 38px rgba(45, 212, 191, 0.2);
+  transform: translateY(-2px);
+}
+
+.toggleRow strong {
+  font-size: 1rem;
+  color: #fdf4ff;
+}
+
+.toggleRow p {
+  margin-top: 4px;
+  color: rgba(191, 219, 254, 0.9);
+  font-size: 0.9rem;
+}
+
+.switch {
+  position: relative;
+  width: 54px;
+  height: 30px;
+}
+
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.switch span {
+  position: absolute;
+  cursor: pointer;
+  inset: 0;
+  background: linear-gradient(90deg, rgba(14, 165, 233, 0.25), rgba(59, 130, 246, 0.25));
+  border-radius: 999px;
+  transition: background 0.3s ease, box-shadow 0.3s ease;
+}
+
+.switch span::after {
+  content: '';
+  position: absolute;
+  height: 24px;
+  width: 24px;
+  left: 3px;
+  top: 3px;
+  background: linear-gradient(135deg, #0ea5e9, #6366f1);
+  border-radius: 50%;
+  transition: transform 0.3s ease, background 0.3s ease, box-shadow 0.3s ease;
+  box-shadow: 0 8px 18px rgba(79, 70, 229, 0.35);
+}
+
+.switch input:checked + span {
+  background: linear-gradient(90deg, #34d399, #22d3ee);
+  box-shadow: 0 10px 24px rgba(34, 211, 238, 0.35);
+}
+
+.switch input:checked + span::after {
+  transform: translateX(24px);
+  background: linear-gradient(135deg, #5eead4, #c084fc);
+  box-shadow: 0 10px 24px rgba(96, 165, 250, 0.4);
+}
+
+.sliderRow {
+  align-items: flex-start;
+}
+
+.rangeControl {
+  display: grid;
+  gap: 8px;
+  justify-items: end;
+}
+
+.rangeControl input[type='range'] {
+  accent-color: #60a5fa;
+  width: 200px;
+}
+
+.rangeControl span {
+  font-size: 0.9rem;
+  color: rgba(165, 243, 252, 0.9);
+}
+
+@media (max-width: 768px) {
+  .profileCard,
+  .preferenceCard {
+    padding: 24px 20px;
+  }
+
+  .toggleRow {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .rangeControl {
+    width: 100%;
+    justify-items: stretch;
+  }
+
+  .rangeControl input[type='range'] {
+    width: 100%;
+  }
 }


### PR DESCRIPTION
## Summary
- refresh the settings page copy and controls with a teal and violet accent palette instead of muted greys

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e25e7ae12483339b1d6d3a30ab7fbe