### PR TITLE
Reimagine tablet battle flow

### DIFF
--- a/src/routes/PlayPage.tsx
+++ b/src/routes/PlayPage.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useCallback, useEffect, useMemo, useState } from 'react';
+import { CSSProperties, FormEvent, useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useGame } from '../context/GameContext';
 import { Game } from '../lib/engine';
@@ -35,7 +35,6 @@ export const PlayPage = () => {
   const [zombieAttacking, setZombieAttacking] = useState(false);
   const [zombieDamaged, setZombieDamaged] = useState(false);
   const [playerDamaged, setPlayerDamaged] = useState(false);
-  const [showProjectile, setShowProjectile] = useState(false);
   const [showStars, setShowStars] = useState(false);
   const [encouragingMsg, setEncouragingMsg] = useState('');
   const playSound = useFeedbackSound(settings.audio);
@@ -117,12 +116,10 @@ export const PlayPage = () => {
         const randomMsg = encouragingMessages[Math.floor(Math.random() * encouragingMessages.length)];
         setEncouragingMsg(randomMsg);
         setPlantAttacking(true);
-        setShowProjectile(true);
         setShowStars(true);
         setTimeout(() => {
           setZombieDamaged(true);
-          setShowProjectile(false);
-        }, 300);
+        }, 260);
         setTimeout(() => {
           setPlantAttacking(false);
           setZombieDamaged(false);
@@ -192,188 +189,211 @@ export const PlayPage = () => {
     }
   }, [showExitConfirm, navigate]);
 
+  const totalQuestions = snapshot?.questionTotal ?? level.count;
+  const currentQuestion = snapshot ? snapshot.questionIndex + 1 : question ? 1 : 0;
+  const answeredQuestions = snapshot?.questionIndex ?? 0;
+  const progressPercent = totalQuestions > 0 ? Math.min(100, (answeredQuestions / totalQuestions) * 100) : 0;
+  const timeLeft = snapshot?.timeLeft ?? level.timeSec;
+  const timeTotal = snapshot?.timeTotal ?? level.timeSec;
+  const playerHp = snapshot?.hp.player ?? level.hp?.player ?? 100;
+  const playerHpMax = snapshot?.hpMax.player ?? level.hp?.player ?? 100;
+  const monsterHp = snapshot?.hp.monster ?? level.hp?.monster ?? 100;
+  const monsterHpMax = snapshot?.hpMax.monster ?? level.hp?.monster ?? 100;
+  const playerHpPercent = Math.max(0, Math.round((playerHp / playerHpMax) * 100));
+  const monsterHpPercent = Math.max(0, Math.round((monsterHp / monsterHpMax) * 100));
+  const accuracy = snapshot && snapshot.questionIndex > 0
+    ? Math.round((snapshot.correct / snapshot.questionIndex) * 100)
+    : snapshot?.correct
+    ? 100
+    : 0;
+  const timerAngle = timeTotal > 0 ? Math.round((Math.max(0, timeLeft) / timeTotal) * 360) : 360;
+
+  const keypadButtons: Array<
+    | { key: string; label: string; onPress: () => void; type?: 'button' | 'submit'; variant?: 'action' | 'submit'; span?: 'wide'; }
+  > = [
+    { key: '7', label: '7', onPress: () => handleNumberClick('7') },
+    { key: '8', label: '8', onPress: () => handleNumberClick('8') },
+    { key: '9', label: '9', onPress: () => handleNumberClick('9') },
+    { key: 'del', label: '⌫', onPress: handleDelete, variant: 'action' },
+    { key: '4', label: '4', onPress: () => handleNumberClick('4') },
+    { key: '5', label: '5', onPress: () => handleNumberClick('5') },
+    { key: '6', label: '6', onPress: () => handleNumberClick('6') },
+    { key: 'clear', label: '清空', onPress: handleClear, variant: 'action' },
+    { key: '1', label: '1', onPress: () => handleNumberClick('1') },
+    { key: '2', label: '2', onPress: () => handleNumberClick('2') },
+    { key: '3', label: '3', onPress: () => handleNumberClick('3') },
+    { key: 'minus', label: '−', onPress: () => handleNumberClick('-'), variant: 'action' },
+    { key: '0', label: '0', onPress: () => handleNumberClick('0'), span: 'wide' },
+    {
+      key: 'submit',
+      label: '✓ 提交',
+      onPress: handleSubmit,
+      type: 'submit',
+      variant: 'submit',
+      span: 'wide'
+    }
+  ];
+
   return (
     <div className={`fade-in ${styles.wrapper}`}>
-      <div className={styles.panel}>
-        {/* Left Section - Question and Answer Area */}
-        <div className={styles.leftSection}>
-          <div className={`glass-card`}>
-            <div className={styles.controlButtons}>
-              <button className="btn secondary" onClick={() => navigate('/levels')}>
-                ⬅️ 返回关卡
-              </button>
-              <button 
-                className="btn secondary" 
-                onClick={handleExit}
-                style={{ background: showExitConfirm ? 'linear-gradient(135deg, #ef4444, #dc2626)' : undefined }}
-              >
-                {showExitConfirm ? '⚠️ 确认退出？' : '❌ 退出关卡'}
-              </button>
-            </div>
-
-            <header className={styles.panelHeader}>
-              <div>
-                <span className="tag">{level.category}</span>
-                <h2>{level.name}</h2>
-                <p>{level.desc}</p>
-              </div>
-              <div className={styles.meta}>
-                <span>题量 {level.count}</span>
-                <span>时限 {level.timeSec}s</span>
-                <span>难度 {level.difficulty.toFixed(1)}</span>
-              </div>
-            </header>
+      <header className={`glass-card ${styles.topBar}`}>
+        <div className={styles.levelMeta}>
+          <div className={styles.levelText}>
+            <span className={styles.levelCategory}>🏁 当前关卡</span>
+            <h2>{level.name}</h2>
+            <p>{level.desc}</p>
           </div>
+          <div className={styles.levelProgress}>
+            <span>第 {currentQuestion || 1}/{totalQuestions} 题</span>
+            <div className={styles.progressTrack}>
+              <div className={styles.progressFill} style={{ width: `${progressPercent}%` }} />
+            </div>
+          </div>
+        </div>
+        <div
+          className={`${styles.timerOrb} ${timeLeft <= 10 ? styles.timerCritical : ''}`}
+          style={{ '--timer-angle': `${timerAngle}deg` } as CSSProperties}
+        >
+          <div className={styles.timerCore}>
+            <span className={styles.timerLabel}>剩余时间</span>
+            <strong>{formatTime(timeLeft)}</strong>
+          </div>
+        </div>
+      </header>
 
-          <div className={`glass-card ${styles.questionArea}`} style={{ position: 'relative' }}>
-            {showStars && <div className={styles.stars}>⭐✨🌟</div>}
+      <section className={`glass-card ${styles.energyPanel}`}>
+        <div className={styles.energyRow}>
+          <div className={styles.energyMeta}>
+            <span className={styles.energyIcon}>🌻</span>
+            <span className={styles.energyLabel}>我方能量</span>
+          </div>
+          <div
+            className={`${styles.energyBar} ${plantAttacking ? styles.energySurge : ''} ${playerDamaged ? styles.energyHit : ''}`}
+          >
+            <div className={styles.energyFill} style={{ width: `${playerHpPercent}%` }} />
+          </div>
+          <span className={styles.energyValue}>{playerHpPercent}%</span>
+        </div>
+        <div className={styles.energyRow}>
+          <div className={styles.energyMeta}>
+            <span className={styles.energyIcon}>👾</span>
+            <span className={styles.energyLabel}>怪兽能量</span>
+          </div>
+          <div
+            className={`${styles.energyBar} ${zombieAttacking ? styles.energySurge : ''} ${zombieDamaged ? styles.energyHit : ''}`}
+          >
+            <div className={`${styles.energyFill} ${styles.enemy}`} style={{ width: `${monsterHpPercent}%` }} />
+          </div>
+          <span className={styles.energyValue}>{monsterHpPercent}%</span>
+        </div>
+        {snapshot && snapshot.combo > 0 && (
+          <div className={styles.comboBanner}>
+            <span>🔥 连击 x{snapshot.combo}</span>
+          </div>
+        )}
+      </section>
+
+      <main className={styles.stage}>
+        <div className={`glass-card ${styles.questionPanel}`}>
+          {showStars && <div className={styles.starBurst} aria-hidden="true" />}
+          <div className={styles.questionHeader}>
+            <span className={styles.questionIndex}>第 {currentQuestion || 1} 题</span>
+            <span className={styles.questionGoal}>打败僵尸！</span>
+          </div>
+          <div className={styles.questionBody}>
             {question ? (
-              <div className={styles.questionCard}>
-                <span className={styles.counter}>
-                  第 {snapshot ? snapshot.questionIndex + 1 : 1}/{snapshot ? snapshot.questionTotal : level.count} 题
-                </span>
-                <p className={styles.questionText}>{question.text}</p>
-                {feedback && (
-                  <p
-                    className={
-                      feedback.correct
-                        ? styles.feedbackOk
-                        : settings.shake
-                        ? styles.feedbackNg
-                        : styles.feedbackPlain
-                    }
-                  >
-                    {feedback.correct ? encouragingMsg : `❌ 正确答案：${feedback.expected}`}
-                  </p>
-                )}
-              </div>
+              <p className={styles.questionText}>{question.text}</p>
             ) : (
-              <div className={styles.questionCard}>🎮 准备开始...</div>
+              <p className={styles.readyText}>🎮 准备开始...</p>
             )}
-          </div>
-
-          <div className={`glass-card`}>
-            <div className={styles.answerForm}>
-              <input
-                value={answer}
-                onChange={(evt) => setAnswer(evt.target.value)}
-                placeholder="请输入答案"
-                readOnly
-                style={{ textAlign: 'center' }}
-              />
-              <div className={styles.numberPad}>
-                {[1, 2, 3, 4, 5, 6, 7, 8, 9].map((num) => (
-                  <button
-                    key={num}
-                    className={styles.numButton}
-                    onClick={() => handleNumberClick(num.toString())}
-                    type="button"
-                  >
-                    {num}
-                  </button>
-                ))}
-                <button
-                  className={`${styles.numButton} ${styles.special}`}
-                  onClick={() => handleNumberClick('-')}
-                  type="button"
-                >
-                  −
-                </button>
-                <button
-                  className={styles.numButton}
-                  onClick={() => handleNumberClick('0')}
-                  type="button"
-                >
-                  0
-                </button>
-                <button
-                  className={`${styles.numButton} ${styles.delete}`}
-                  onClick={handleDelete}
-                  type="button"
-                >
-                  ⌫
-                </button>
-                <button
-                  className={`${styles.numButton} ${styles.submit}`}
-                  onClick={handleSubmit}
-                  type="button"
-                >
-                  ✓ 提交答案
-                </button>
-              </div>
+            <div className={styles.answerWindow}>
+              <input value={answer} placeholder="输入答案" readOnly />
             </div>
           </div>
+          {feedback && (
+            <div
+              className={`${
+                feedback.correct
+                  ? styles.feedbackPositive
+                  : settings.shake
+                  ? styles.feedbackNegative
+                  : styles.feedbackNeutral
+              } ${styles.feedbackToast}`}
+            >
+              {feedback.correct ? encouragingMsg : `❌ 正确答案：${feedback.expected}`}
+            </div>
+          )}
         </div>
 
-        {/* Right Section - Battle Animation and Stats */}
-        <div className={styles.rightSection}>
-          <div className={`glass-card`}>
-            <div className={styles.battleField}>
-              <div className={styles.characterWrapper}>
-                <div className={`${styles.hpBar} ${((snapshot?.hp.player ?? level.hp?.player ?? 100) / (snapshot?.hpMax.player ?? level.hp?.player ?? 100)) <= 0.3 ? styles.lowHp : ''}`}>
-                  <div
-                    className={`${styles.hpFill} ${styles.player}`}
-                    style={{ width: `${((snapshot?.hp.player ?? level.hp?.player ?? 100) / (snapshot?.hpMax.player ?? level.hp?.player ?? 100)) * 100}%` }}
-                  />
-                </div>
-                <div className={`${styles.character} ${styles.plant} ${plantAttacking ? styles.attacking : ''} ${playerDamaged ? styles.damaged : ''}`}>
-                  🌻
-                </div>
-              </div>
-              {showProjectile && <div className={styles.projectile}>🌰</div>}
-              <div className={styles.characterWrapper}>
-                <div className={`${styles.hpBar} ${((snapshot?.hp.monster ?? level.hp?.monster ?? 100) / (snapshot?.hpMax.monster ?? level.hp?.monster ?? 100)) <= 0.3 ? styles.lowHp : ''}`}>
-                  <div
-                    className={`${styles.hpFill} ${styles.monster}`}
-                    style={{ width: `${((snapshot?.hp.monster ?? level.hp?.monster ?? 100) / (snapshot?.hpMax.monster ?? level.hp?.monster ?? 100)) * 100}%` }}
-                  />
-                </div>
-                <div className={`${styles.character} ${styles.zombie} ${zombieAttacking ? styles.attacking : ''} ${zombieDamaged ? styles.damaged : ''}`}>
-                  🧟
-                </div>
-              </div>
-            </div>
-          </div>
+        <form className={`glass-card ${styles.keypadPanel}`} onSubmit={onSubmit}>
+          <div className={styles.padGrid}>
+            {keypadButtons.map(({ key, label, onPress, type = 'button', variant, span }) => {
+              const variantClass =
+                variant === 'action' ? styles.padAction : variant === 'submit' ? styles.padSubmit : '';
+              const spanClass = span === 'wide' ? styles.padWide : '';
+              const classes = [styles.padButton, variantClass, spanClass].filter(Boolean).join(' ');
 
-          <div className={`glass-card`}>
-            <div className={styles.statsArea}>
-              <div className={`${styles.timer} ${(snapshot?.timeLeft ?? level.timeSec) <= 10 ? styles.warning : ''}`}>
-                ⏱️ {formatTime(snapshot?.timeLeft ?? level.timeSec)}
-              </div>
-              {snapshot && snapshot.combo > 0 && (
-                <div className={`${styles.comboDisplay} ${snapshot.combo >= 10 ? styles.ultra : snapshot.combo >= 5 ? styles.high : ''}`}>
-                  🔥 连击 x{snapshot.combo} 🔥
-                </div>
-              )}
-              <div className={styles.statItem}>
-                <span className={styles.statLabel}>当前题目</span>
-                <span className={styles.statValue}>
-                  {snapshot ? snapshot.questionIndex + 1 : 1} / {snapshot ? snapshot.questionTotal : level.count}
-                </span>
-              </div>
-              <div className={styles.statItem}>
-                <span className={styles.statLabel}>正确率</span>
-                <span className={styles.statValue}>
-                  {snapshot && snapshot.questionIndex > 0
-                    ? Math.round((snapshot.correct / snapshot.questionIndex) * 100)
-                    : snapshot?.correct
-                    ? 100
-                    : 0}
-                  %
-                </span>
-              </div>
-              <div className={styles.statItem}>
-                <span className={styles.statLabel}>当前连击</span>
-                <span className={styles.statValue}>{snapshot?.combo ?? 0}</span>
-              </div>
-              <div className={styles.statItem}>
-                <span className={styles.statLabel}>最高连击</span>
-                <span className={styles.statValue}>{snapshot?.maxCombo ?? 0}</span>
-              </div>
-            </div>
+              return (
+                <button
+                  key={key}
+                  type={type}
+                  onClick={(evt) => {
+                    if (type === 'submit') {
+                      evt.preventDefault();
+                      if (!answer.trim() || state !== 'playing') return;
+                    }
+                    onPress();
+                  }}
+                  disabled={type === 'submit' && (!answer.trim() || state !== 'playing')}
+                  className={classes}
+                >
+                  {label}
+                </button>
+              );
+            })}
+          </div>
+        </form>
+      </main>
+
+      <footer className={`glass-card ${styles.bottomPanel}`}>
+        <div className={styles.bottomStats}>
+          <div>
+            <span className={styles.statLabel}>进度</span>
+            <strong className={styles.statValue}>
+              {answeredQuestions}/{totalQuestions}
+            </strong>
+          </div>
+          <div>
+            <span className={styles.statLabel}>正确率</span>
+            <strong className={styles.statValue}>{accuracy}%</strong>
+          </div>
+          <div>
+            <span className={styles.statLabel}>最高连击</span>
+            <strong className={styles.statValue}>{snapshot?.maxCombo ?? 0}</strong>
           </div>
         </div>
-      </div>
+        <div className={styles.bottomProgress}>
+          <div className={styles.progressTrack}>
+            <div className={styles.progressFill} style={{ width: `${progressPercent}%` }} />
+          </div>
+          <span className={styles.progressHint}>再答 {Math.max(0, totalQuestions - answeredQuestions)} 题就能赢！</span>
+        </div>
+        <div className={styles.actionRow}>
+          <button className="btn secondary" onClick={() => navigate('/levels')}>
+            ⬅️ 返回关卡
+          </button>
+          <button
+            className="btn secondary"
+            onClick={handleExit}
+            style={{ background: showExitConfirm ? 'linear-gradient(135deg, #ef4444, #dc2626)' : undefined }}
+          >
+            {showExitConfirm ? '⚠️ 确认退出？' : '❌ 退出关卡'}
+          </button>
+          <button className="btn" onClick={handleSubmit} disabled={!answer.trim() || state !== 'playing'}>
+            ✓ 提交答案
+          </button>
+        </div>
+      </footer>
     </div>
   );
 };

--- a/src/routes/ResultPage.tsx
+++ b/src/routes/ResultPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { CSSProperties, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useGame } from '../context/GameContext';
 import { findLevel } from '../lib/levels';
@@ -23,56 +23,99 @@ export const ResultPage = () => {
 
   const isVictory = lastResult.outcome === 'victory';
   const isDefeat = lastResult.outcome === 'defeat' || lastResult.outcome === 'timeout';
+  const answered = lastResult.history?.length ?? lastResult.total;
+  const progressPercent = lastResult.total > 0 ? Math.round((answered / lastResult.total) * 100) : 0;
+
+  const progressStyle = { '--progress': `${progressPercent}%` } as CSSProperties;
+
+  const mood = (() => {
+    if (isVictory) {
+      return {
+        icon: '🏆',
+        title: '胜利啦！',
+        subtitle: '太棒了！你成功击败了算术怪兽！',
+        encouragement: '保持热度，继续挑战更高难度吧！'
+      };
+    }
+
+    const accuracyValue = lastResult.total > 0 ? lastResult.correct / lastResult.total : 0;
+    let subtitle = '被怪兽压制了，不过战斗经验+1！';
+    if (lastResult.outcome === 'timeout') {
+      subtitle = '时间耗尽了，不过你离胜利只差一点！';
+    }
+    if (accuracyValue === 0) {
+      subtitle = '别灰心，先熟悉题型，再来复仇！';
+    }
+
+    let encouragement = '加油！再战一次你一定能击败算术怪兽！';
+    if (accuracyValue >= 0.7) {
+      encouragement = '只差一点点，再坚持几题就能赢！';
+    } else if (accuracyValue >= 0.4) {
+      encouragement = '已经掌握一半了，调匀节奏继续冲！';
+    }
+
+    return {
+      icon: '😢',
+      title: '挑战失败',
+      subtitle,
+      encouragement
+    };
+  })();
 
   return (
-    <div className="fade-in">
-      <section className={`glass-card ${styles.card} ${isVictory ? styles.victory : ''} ${isDefeat ? styles.defeat : ''}`}>
-        <div className={styles.resultHeader}>
-          {isVictory && (
-            <div className={styles.victoryBanner}>
-              <div className={styles.trophy}>🏆</div>
-              <h2 className={styles.victoryTitle}>胜利！</h2>
-              <p className={styles.victorySubtitle}>太棒了！你成功击败了僵尸！</p>
+    <div className={`fade-in ${styles.wrapper}`}>
+      <section className={`glass-card ${styles.board} ${isVictory ? styles.victory : ''} ${isDefeat ? styles.defeat : ''}`}>
+        <header className={styles.moodSection}>
+          <div className={styles.moodIcon}>{mood.icon}</div>
+          <div>
+            <h2 className={styles.moodTitle}>{mood.title}</h2>
+            <p className={styles.moodSubtitle}>{mood.subtitle}</p>
+          </div>
+        </header>
+
+        <p className={styles.encouragement}>{mood.encouragement}</p>
+
+        <div className={styles.scoreCard}>
+          <div className={styles.levelBadge}>{level?.name ?? lastResult.levelName ?? '挑战结果'}</div>
+          <div className={styles.statGrid}>
+            <div>
+              <span className={styles.statLabel}>得分</span>
+              <strong className={styles.statValue}>{lastResult.score}</strong>
             </div>
-          )}
-          {isDefeat && (
-            <div className={styles.defeatBanner}>
-              <div className={styles.defeatIcon}>😢</div>
-              <h2 className={styles.defeatTitle}>失败了</h2>
-              <p className={styles.defeatSubtitle}>
-                {lastResult.outcome === 'timeout' ? '时间耗尽了，再接再厉！' : '被僵尸打败了，下次加油！'}
-              </p>
+            <div>
+              <span className={styles.statLabel}>正确率</span>
+              <strong className={styles.statValue}>{formatPercent(lastResult.accuracy)}</strong>
             </div>
-          )}
+            <div>
+              <span className={styles.statLabel}>最高连击</span>
+              <strong className={styles.statValue}>{lastResult.comboMax}</strong>
+            </div>
+            <div>
+              <span className={styles.statLabel}>用时</span>
+              <strong className={styles.statValue}>{lastResult.timeUsed}s</strong>
+            </div>
+          </div>
+          <div className={styles.progressCard}>
+            <div className={styles.progressInfo}>
+              <span>进度</span>
+              <strong>
+                {answered}/{lastResult.total}
+              </strong>
+            </div>
+            <div className={styles.progressTrack} style={progressStyle}>
+              <div className={styles.progressFill} />
+            </div>
+          </div>
         </div>
 
-        <h3 className={styles.levelName}>{level?.name ?? lastResult.levelName ?? '挑战结果'}</h3>
-
-        <div className={styles.summary}>
-          <div>
-            <span className="tag">得分</span>
-            <p>{lastResult.score}</p>
-          </div>
-          <div>
-            <span className="tag">正确率</span>
-            <p>{formatPercent(lastResult.accuracy)}</p>
-          </div>
-          <div>
-            <span className="tag">连击</span>
-            <p>{lastResult.comboMax}</p>
-          </div>
-          <div>
-            <span className="tag">用时</span>
-            <p>{lastResult.timeUsed}s</p>
-          </div>
-        </div>
         <div className={styles.actions}>
           <button className="btn" onClick={() => navigate(`/play/${lastResult.levelId}`)}>
-            再战一次
+            🔁 再战一次
           </button>
           <button className="btn secondary" onClick={() => navigate('/levels')}>
-            选择新关卡
+            🎯 选择新关卡
           </button>
+          <button className="btn secondary" onClick={() => navigate('/')}>🏠 返回首页</button>
         </div>
       </section>
     </div>

--- a/src/styles/PlayPage.module.css
+++ b/src/styles/PlayPage.module.css
@@ -1,648 +1,619 @@
 .wrapper {
+  position: relative;
+  min-height: 100vh;
+  padding: clamp(24px, 4vw, 48px) clamp(16px, 5vw, 80px) clamp(140px, 12vh, 180px);
   display: flex;
-  justify-content: center;
-  width: 100%;
+  flex-direction: column;
+  align-items: center;
+  gap: clamp(18px, 3vw, 28px);
+  background: radial-gradient(circle at top, rgba(255, 237, 213, 0.85), rgba(254, 215, 170, 0.65)),
+    linear-gradient(180deg, rgba(253, 186, 116, 0.45), rgba(249, 115, 22, 0.35));
+  overflow-x: hidden;
 }
 
-.panel {
-  max-width: 1400px;
-  width: 100%;
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 32px;
-  align-items: start;
+.wrapper::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.35), transparent 55%),
+    radial-gradient(circle at 80% 15%, rgba(254, 215, 170, 0.45), transparent 60%);
+  pointer-events: none;
+  opacity: 0.65;
 }
 
-.leftSection {
-  display: grid;
-  gap: 28px;
-}
-
-.rightSection {
-  display: grid;
-  gap: 28px;
-  position: sticky;
-  top: 20px;
-}
-
-.panelHeader {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
-  gap: 16px;
-}
-
-.panelHeader h2 {
-  margin-top: 8px;
-}
-
-.meta {
-  display: grid;
-  gap: 8px;
-  color: #c2410c;
-  font-size: 0.95rem;
-  font-weight: 600;
-}
-
-.statsArea {
-  display: grid;
-  gap: 20px;
-  padding: 24px;
-  border-radius: 20px;
-  background: linear-gradient(135deg, rgba(255, 247, 237, 0.95), rgba(254, 243, 199, 0.9));
-  border: 3px solid rgba(249, 115, 22, 0.3);
-}
-
-.statItem {
+.topBar {
+  position: relative;
+  width: min(1080px, 100%);
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 12px 16px;
-  border-radius: 12px;
-  background: rgba(255, 255, 255, 0.6);
-  border: 2px solid rgba(249, 115, 22, 0.2);
+  gap: clamp(16px, 3vw, 36px);
+  padding: clamp(20px, 3vw, 32px) clamp(24px, 4vw, 40px);
+  border-radius: 28px;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.92), rgba(255, 247, 237, 0.92));
+  border: 3px solid rgba(249, 115, 22, 0.35);
+  box-shadow: 0 22px 45px rgba(234, 88, 12, 0.18);
+  z-index: 2;
 }
 
-.statLabel {
-  font-weight: 600;
+.levelMeta {
+  display: flex;
+  flex: 1;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: clamp(16px, 3vw, 36px);
+}
+
+.levelText {
+  display: grid;
+  gap: 8px;
+}
+
+.levelText h2 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 800;
+  color: #7c2d12;
+}
+
+.levelText p {
+  margin: 0;
+  max-width: 420px;
   color: #9a3412;
-  font-size: 0.95rem;
-}
-
-.statValue {
-  font-weight: 700;
-  color: #ea580c;
-  font-size: 1.1rem;
-  transition: all 0.2s ease;
-}
-
-.statValue.increment {
-  animation: scoreIncrement 0.5s ease-out;
-}
-
-@keyframes scoreIncrement {
-  0% {
-    transform: scale(1);
-    color: #ea580c;
-  }
-  50% {
-    transform: scale(1.3);
-    color: #10b981;
-  }
-  100% {
-    transform: scale(1);
-    color: #ea580c;
-  }
-}
-
-.timer {
-  text-align: center;
-  padding: 16px;
-  border-radius: 16px;
-  background: linear-gradient(135deg, #fbbf24, #f59e0b);
-  color: #fff;
-  font-weight: 800;
-  font-size: 1.5rem;
-  box-shadow: 0 4px 12px rgba(245, 158, 11, 0.4);
-  transition: all 0.3s ease;
-}
-
-.timer.warning {
-  background: linear-gradient(135deg, #ef4444, #dc2626);
-  animation: timerPulse 0.8s ease-in-out infinite;
-  box-shadow: 0 4px 20px rgba(239, 68, 68, 0.6);
-}
-
-@keyframes timerPulse {
-  0%, 100% {
-    transform: scale(1);
-    box-shadow: 0 4px 20px rgba(239, 68, 68, 0.6);
-  }
-  50% {
-    transform: scale(1.05);
-    box-shadow: 0 6px 25px rgba(239, 68, 68, 0.8);
-  }
-}
-
-.comboDisplay {
-  text-align: center;
-  padding: 12px 24px;
-  border-radius: 16px;
-  background: linear-gradient(135deg, #fbbf24, #f59e0b);
-  color: #fff;
-  font-weight: 800;
-  font-size: 1.3rem;
-  box-shadow: 0 4px 12px rgba(245, 158, 11, 0.4);
-  animation: comboPulse 0.5s ease;
-}
-
-.comboDisplay.high {
-  background: linear-gradient(135deg, #f97316, #ea580c);
-  animation: comboPulse 0.4s ease, comboShake 0.4s ease;
-  box-shadow: 0 4px 20px rgba(249, 115, 22, 0.6);
-}
-
-.comboDisplay.ultra {
-  background: linear-gradient(135deg, #ef4444, #dc2626);
-  animation: comboPulse 0.3s ease, comboShake 0.3s ease, comboFlame 1s ease-in-out infinite;
-  box-shadow: 0 4px 24px rgba(239, 68, 68, 0.8);
-  font-size: 1.5rem;
-}
-
-@keyframes comboFlame {
-  0%, 100% {
-    filter: hue-rotate(0deg) brightness(1);
-  }
-  50% {
-    filter: hue-rotate(10deg) brightness(1.2);
-  }
-}
-
-@keyframes comboPulse {
-  0% {
-    transform: scale(1);
-  }
-  50% {
-    transform: scale(1.15);
-  }
-  100% {
-    transform: scale(1);
-  }
-}
-
-@keyframes comboShake {
-  0%, 100% { transform: rotate(0deg) scale(1); }
-  25% { transform: rotate(-5deg) scale(1.1); }
-  75% { transform: rotate(5deg) scale(1.1); }
-}
-
-.stars {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  font-size: 3rem;
-  animation: starburst 1s ease-out forwards;
-  pointer-events: none;
-  z-index: 10;
-}
-
-@keyframes starburst {
-  0% {
-    opacity: 1;
-    transform: translate(-50%, -50%) scale(0) rotate(0deg);
-  }
-  50% {
-    opacity: 1;
-    transform: translate(-50%, -50%) scale(1.5) rotate(180deg);
-  }
-  100% {
-    opacity: 0;
-    transform: translate(-50%, -50%) scale(2) rotate(360deg);
-  }
-}
-
-.questionArea {
-  display: grid;
-}
-
-.questionCard {
-  border-radius: 20px;
-  padding: 32px;
-  border: 3px solid rgba(249, 115, 22, 0.4);
-  background: linear-gradient(135deg, rgba(255, 247, 237, 0.95), rgba(254, 243, 199, 0.9));
-  min-height: 200px;
-  display: grid;
-  gap: 24px;
-  align-content: start;
-  box-shadow: 0 8px 25px rgba(234, 88, 12, 0.15);
-  animation: questionSlideIn 0.4s ease-out;
-}
-
-@keyframes questionSlideIn {
-  from {
-    opacity: 0;
-    transform: translateY(20px) scale(0.98);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0) scale(1);
-  }
-}
-
-.counter {
-  font-size: 1rem;
-  color: #ea580c;
   font-weight: 600;
+  opacity: 0.85;
+}
+
+.levelCategory {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(249, 115, 22, 0.18), rgba(251, 191, 36, 0.22));
+  color: #9a3412;
+  font-weight: 700;
+  font-size: 0.9rem;
+}
+
+.levelProgress {
+  display: grid;
+  gap: 12px;
+  min-width: clamp(200px, 25vw, 260px);
+  font-weight: 700;
+  color: #c2410c;
+}
+
+.levelProgress span {
+  font-size: 1.05rem;
+}
+
+.progressTrack {
+  position: relative;
+  height: 12px;
+  border-radius: 999px;
+  background: rgba(254, 215, 170, 0.8);
+  overflow: hidden;
+}
+
+.progressFill {
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(135deg, #f97316, #ea580c);
+  transition: width 0.35s ease;
+}
+
+.timerOrb {
+  position: relative;
+  width: clamp(140px, 14vw, 180px);
+  aspect-ratio: 1/1;
+  border-radius: 50%;
+  background: conic-gradient(#f97316 var(--timer-angle), rgba(255, 255, 255, 0.2) 0);
+  display: grid;
+  place-items: center;
+  padding: 12px;
+  box-shadow: 0 18px 40px rgba(234, 88, 12, 0.35);
+  transition: transform 0.3s ease;
+}
+
+.timerOrb::after {
+  content: '';
+  position: absolute;
+  inset: 10px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.9), rgba(255, 237, 213, 0.85));
+}
+
+.timerOrb:hover {
+  transform: scale(1.03);
+}
+
+.timerCritical {
+  animation: timerPulse 0.9s ease-in-out infinite;
+  background: conic-gradient(#ef4444 var(--timer-angle), rgba(255, 255, 255, 0.15) 0);
+  box-shadow: 0 18px 45px rgba(239, 68, 68, 0.45);
+}
+
+.timerCore {
+  position: relative;
+  display: grid;
+  gap: 4px;
+  text-align: center;
+  z-index: 1;
+}
+
+.timerLabel {
+  font-size: 0.95rem;
+  color: #9a3412;
+  font-weight: 600;
+}
+
+.timerCore strong {
+  font-size: clamp(1.5rem, 3.4vw, 2.2rem);
+  font-weight: 800;
+  color: #7c2d12;
+}
+
+.energyPanel {
+  position: relative;
+  width: min(1020px, 100%);
+  padding: clamp(18px, 2.6vw, 28px) clamp(18px, 3vw, 32px);
+  border-radius: 26px;
+  background: linear-gradient(120deg, rgba(255, 255, 255, 0.95), rgba(254, 243, 199, 0.85));
+  border: 3px solid rgba(249, 115, 22, 0.3);
+  box-shadow: 0 18px 40px rgba(234, 88, 12, 0.16);
+  display: grid;
+  gap: clamp(14px, 2vw, 20px);
+  overflow: hidden;
+}
+
+.energyRow {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: clamp(12px, 2vw, 24px);
+}
+
+.energyMeta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.energyIcon {
+  font-size: clamp(1.6rem, 2.8vw, 2.2rem);
+}
+
+.energyLabel {
+  font-weight: 700;
+  color: #9a3412;
+}
+
+.energyBar {
+  position: relative;
+  height: clamp(18px, 1.8vw, 22px);
+  border-radius: 999px;
+  background: rgba(254, 215, 170, 0.75);
+  overflow: hidden;
+  transition: transform 0.35s ease;
+}
+
+.energyFill {
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(135deg, #4ade80, #22c55e);
+  transition: width 0.35s ease, filter 0.3s ease;
+}
+
+.enemy {
+  background: linear-gradient(135deg, #f97316, #fb7185);
+}
+
+.energyValue {
+  font-weight: 800;
+  color: #7c2d12;
+}
+
+.energySurge {
+  animation: surge 0.5s ease;
+}
+
+.energyHit {
+  animation: hitFlash 0.45s ease;
+}
+
+.comboBanner {
+  margin-top: 4px;
+  padding: 10px 16px;
+  border-radius: 14px;
+  background: linear-gradient(135deg, rgba(249, 115, 22, 0.25), rgba(251, 191, 36, 0.25));
+  color: #7c2d12;
+  font-weight: 700;
+  justify-self: start;
+  animation: comboGlow 1.2s ease-in-out infinite;
+}
+
+.stage {
+  position: relative;
+  width: min(960px, 100%);
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: clamp(20px, 3vw, 32px);
+  align-items: stretch;
+}
+
+.questionPanel {
+  position: relative;
+  padding: clamp(28px, 4vw, 40px);
+  border-radius: 34px;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(254, 243, 199, 0.92));
+  border: 3px solid rgba(249, 115, 22, 0.35);
+  box-shadow: 0 24px 50px rgba(234, 88, 12, 0.18);
+  overflow: hidden;
+  min-height: clamp(300px, 38vh, 360px);
+  display: grid;
+  gap: clamp(16px, 3vw, 28px);
+}
+
+.starBurst {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 30% 30%, rgba(251, 191, 36, 0.35), transparent 45%),
+    radial-gradient(circle at 70% 20%, rgba(255, 255, 255, 0.5), transparent 50%);
+  animation: burst 0.65s ease;
+  pointer-events: none;
+}
+
+.questionHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  z-index: 1;
+}
+
+.questionIndex,
+.questionGoal {
+  padding: 8px 16px;
+  border-radius: 999px;
+  font-weight: 700;
+  color: #9a3412;
+  background: rgba(254, 215, 170, 0.7);
+}
+
+.questionGoal {
+  background: rgba(16, 185, 129, 0.18);
+  color: #047857;
+}
+
+.questionBody {
+  display: grid;
+  gap: clamp(16px, 3vw, 28px);
+  text-align: center;
+  z-index: 1;
 }
 
 .questionText {
-  font-size: 2.5rem;
+  font-size: clamp(2.8rem, 8vw, 4.6rem);
+  font-weight: 900;
+  color: #7c2d12;
+  letter-spacing: 0.04em;
+  text-shadow: 0 12px 35px rgba(249, 115, 22, 0.25);
+  animation: questionPop 0.5s ease;
+}
+
+.readyText {
+  font-size: clamp(1.4rem, 3.6vw, 2.2rem);
+  font-weight: 700;
+  color: #c2410c;
+}
+
+.answerWindow {
+  display: flex;
+  justify-content: center;
+}
+
+.answerWindow input {
+  width: min(360px, 70%);
+  padding: clamp(14px, 2.6vw, 22px);
+  border-radius: 20px;
+  border: 3px solid rgba(249, 115, 22, 0.35);
+  background: rgba(255, 255, 255, 0.95);
+  font-size: clamp(2rem, 5vw, 2.8rem);
   font-weight: 800;
-  letter-spacing: 0.05em;
-  color: #9a3412;
-  text-shadow: 2px 2px 4px rgba(249, 115, 22, 0.1);
+  color: #7c2d12;
+  text-align: center;
+  box-shadow: inset 0 4px 12px rgba(249, 115, 22, 0.15);
 }
 
-.feedbackOk {
-  color: #10b981;
+.feedbackToast {
+  position: absolute;
+  top: 18px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 12px 24px;
+  border-radius: 18px;
   font-weight: 700;
-  font-size: 1.3rem;
-  animation: pop 0.6s ease, glow 1s ease-in-out infinite;
-  text-shadow: 0 0 10px rgba(16, 185, 129, 0.5);
+  font-size: 1.05rem;
+  box-shadow: 0 12px 32px rgba(16, 185, 129, 0.24);
+  animation: pop 0.55s ease;
+  z-index: 2;
 }
 
-.feedbackNg {
-  color: #ef4444;
-  font-weight: 700;
-  font-size: 1.1rem;
+.feedbackPositive {
+  background: linear-gradient(135deg, rgba(16, 185, 129, 0.95), rgba(5, 150, 105, 0.9));
+  color: #ecfdf5;
+}
+
+.feedbackNegative {
+  background: linear-gradient(135deg, rgba(239, 68, 68, 0.95), rgba(220, 38, 38, 0.9));
+  color: #fff5f5;
   animation: shake 0.45s ease;
-  text-shadow: 0 0 10px rgba(239, 68, 68, 0.5);
 }
 
-.feedbackPlain {
-  color: #ef4444;
+.feedbackNeutral {
+  background: rgba(239, 68, 68, 0.92);
+  color: #fff5f5;
+}
+
+.keypadPanel {
+  padding: clamp(24px, 3.6vw, 36px);
+  border-radius: 32px;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(255, 247, 237, 0.9));
+  border: 3px solid rgba(249, 115, 22, 0.3);
+  box-shadow: 0 22px 48px rgba(234, 88, 12, 0.16);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.padGrid {
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(64px, 1fr));
+  gap: clamp(12px, 2.2vw, 18px);
+}
+
+.padButton {
+  border: none;
+  border-radius: 18px;
+  padding: clamp(14px, 2.6vw, 22px);
+  font-size: clamp(1.4rem, 3.6vw, 2.2rem);
+  font-weight: 800;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.92), rgba(254, 243, 199, 0.9));
+  color: #7c2d12;
+  box-shadow: 0 12px 24px rgba(234, 88, 12, 0.18);
+  cursor: pointer;
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.padButton:active {
+  transform: scale(0.96);
+  box-shadow: 0 6px 16px rgba(234, 88, 12, 0.22);
+}
+
+.padButton:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.padAction {
+  font-size: clamp(1.1rem, 2.6vw, 1.6rem);
   font-weight: 700;
-  font-size: 1.1rem;
+  background: linear-gradient(135deg, rgba(254, 215, 170, 0.85), rgba(253, 186, 116, 0.85));
 }
 
-@keyframes glow {
-  0%, 100% {
-    text-shadow: 0 0 10px rgba(16, 185, 129, 0.5);
+.padSubmit {
+  background: linear-gradient(135deg, #16a34a, #22c55e);
+  color: #fefce8;
+  box-shadow: 0 16px 32px rgba(34, 197, 94, 0.35);
+}
+
+.padSubmit:disabled {
+  background: linear-gradient(135deg, rgba(74, 222, 128, 0.5), rgba(22, 163, 74, 0.5));
+  box-shadow: none;
+}
+
+.padWide {
+  grid-column: span 2;
+}
+
+.bottomPanel {
+  position: sticky;
+  bottom: clamp(20px, 5vh, 40px);
+  width: min(960px, 100%);
+  display: grid;
+  gap: clamp(16px, 2.6vw, 24px);
+  padding: clamp(22px, 3.2vw, 32px);
+  border-radius: 30px;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(255, 247, 237, 0.92));
+  border: 3px solid rgba(249, 115, 22, 0.3);
+  box-shadow: 0 24px 48px rgba(234, 88, 12, 0.2);
+  z-index: 3;
+}
+
+.bottomStats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: clamp(12px, 2vw, 20px);
+}
+
+.bottomStats div {
+  padding: 14px 18px;
+  border-radius: 18px;
+  background: linear-gradient(135deg, rgba(254, 215, 170, 0.6), rgba(253, 186, 116, 0.45));
+  border: 2px solid rgba(249, 115, 22, 0.35);
+  text-align: center;
+}
+
+.statLabel {
+  display: block;
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: #9a3412;
+  margin-bottom: 6px;
+}
+
+.statValue {
+  font-size: clamp(1.4rem, 3vw, 1.8rem);
+  color: #7c2d12;
+  font-weight: 800;
+}
+
+.bottomProgress {
+  display: grid;
+  gap: 8px;
+  text-align: center;
+}
+
+.progressHint {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #9a3412;
+}
+
+.actionRow {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: clamp(12px, 2vw, 20px);
+}
+
+@keyframes timerPulse {
+  0%,
+  100% {
+    transform: scale(1);
   }
   50% {
-    text-shadow: 0 0 20px rgba(16, 185, 129, 0.8), 0 0 30px rgba(16, 185, 129, 0.6);
+    transform: scale(1.06);
+  }
+}
+
+@keyframes surge {
+  0% {
+    transform: scaleY(1);
+  }
+  40% {
+    transform: scaleY(1.12);
+  }
+  100% {
+    transform: scaleY(1);
+  }
+}
+
+@keyframes hitFlash {
+  0% {
+    filter: brightness(1);
+  }
+  50% {
+    filter: brightness(1.45);
+  }
+  100% {
+    filter: brightness(1);
+  }
+}
+
+@keyframes comboGlow {
+  0%,
+  100% {
+    box-shadow: 0 0 12px rgba(249, 115, 22, 0.35);
+  }
+  50% {
+    box-shadow: 0 0 24px rgba(251, 191, 36, 0.5);
+  }
+}
+
+@keyframes burst {
+  0% {
+    opacity: 0.8;
+    transform: scale(0.9);
+  }
+  100% {
+    opacity: 0;
+    transform: scale(1.1);
   }
 }
 
 @keyframes pop {
   0% {
-    transform: scale(0.92);
+    transform: translate(-50%, -10px) scale(0.95);
     opacity: 0;
   }
-  60% {
-    transform: scale(1.05);
-  }
   100% {
-    transform: scale(1);
+    transform: translate(-50%, 0) scale(1);
     opacity: 1;
   }
 }
 
 @keyframes shake {
-  10%,
-  90% {
-    transform: translateX(-1px);
-  }
-  20%,
-  80% {
-    transform: translateX(2px);
-  }
-  30%,
-  50%,
-  70% {
-    transform: translateX(-4px);
-  }
-  40%,
-  60% {
-    transform: translateX(4px);
-  }
-}
-
-.answerForm {
-  display: grid;
-  gap: 24px;
-}
-
-.answerForm input {
-  padding: 20px 24px;
-  border-radius: 16px;
-  border: 3px solid rgba(249, 115, 22, 0.4);
-  background: rgba(255, 255, 255, 0.9);
-  color: #7c2d12;
-  font-size: 1.5rem;
-  font-weight: 700;
-}
-
-.answerForm input:focus {
-  outline: none;
-  border-color: rgba(249, 115, 22, 0.7);
-  box-shadow: 0 0 0 4px rgba(249, 115, 22, 0.2);
-}
-
-.numberPad {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 14px;
-  max-width: 100%;
-}
-
-.numButton {
-  padding: 20px;
-  border-radius: 16px;
-  border: 2px solid rgba(249, 115, 22, 0.3);
-  background: linear-gradient(135deg, #fdba74, #fb923c);
-  color: #fff;
-  font-size: 1.8rem;
-  font-weight: 800;
-  cursor: pointer;
-  transition: all 0.2s ease;
-  box-shadow: 0 4px 12px rgba(249, 115, 22, 0.3);
-  will-change: transform, box-shadow;
-}
-
-.numButton:hover {
-  transform: translateY(-3px) scale(1.05);
-  box-shadow: 0 8px 20px rgba(249, 115, 22, 0.4);
-  background: linear-gradient(135deg, #fb923c, #f97316);
-}
-
-.numButton:active {
-  transform: translateY(0) scale(0.95);
-  animation: buttonRipple 0.5s ease-out;
-}
-
-@keyframes buttonRipple {
-  0% {
-    box-shadow: 0 0 0 0 rgba(249, 115, 22, 0.7), inset 0 0 0 0 rgba(255, 255, 255, 0.3);
-  }
-  50% {
-    box-shadow: 0 0 0 10px rgba(249, 115, 22, 0), inset 0 0 20px 5px rgba(255, 255, 255, 0.5);
-  }
+  0%,
   100% {
-    box-shadow: 0 0 0 20px rgba(249, 115, 22, 0), inset 0 0 0 0 rgba(255, 255, 255, 0);
-  }
-}
-
-.numButton.special {
-  background: linear-gradient(135deg, #f97316, #ea580c);
-  font-size: 1.2rem;
-}
-
-.numButton.delete {
-  background: linear-gradient(135deg, #ef4444, #dc2626);
-}
-
-.numButton.submit {
-  background: linear-gradient(135deg, #10b981, #059669);
-  grid-column: span 3;
-}
-
-.controlButtons {
-  display: flex;
-  gap: 12px;
-  justify-content: center;
-  flex-wrap: wrap;
-}
-
-.battleField {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
-  padding: 32px 24px 24px;
-  border-radius: 20px;
-  background: linear-gradient(135deg, rgba(254, 249, 195, 0.5), rgba(253, 224, 71, 0.3));
-  border: 3px solid rgba(234, 179, 8, 0.4);
-  min-height: 280px;
-  position: relative;
-  overflow: visible;
-}
-
-.characterWrapper {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 8px;
-  position: relative;
-}
-
-.character {
-  font-size: 5rem;
-  filter: drop-shadow(0 6px 12px rgba(0, 0, 0, 0.25));
-  position: relative;
-  z-index: 2;
-  will-change: transform;
-}
-
-.hpBar {
-  width: 80px;
-  height: 12px;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.6);
-  overflow: hidden;
-  border: 2px solid rgba(249, 115, 22, 0.3);
-  position: relative;
-}
-
-.hpFill {
-  height: 100%;
-  transition: width 0.35s ease;
-  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.2);
-  will-change: width;
-}
-
-.hpFill.monster {
-  background: linear-gradient(90deg, #ef4444, #f97316);
-}
-
-.hpFill.player {
-  background: linear-gradient(90deg, #10b981, #34d399);
-}
-
-.hpBar.draining .hpFill {
-  animation: hpDrain 0.4s ease-out;
-}
-
-.hpBar.lowHp .hpFill {
-  animation: lowHpWarning 1s ease-in-out infinite;
-}
-
-@keyframes hpDrain {
-  0%, 100% {
-    opacity: 1;
-    filter: brightness(1);
-  }
-  50% {
-    opacity: 0.7;
-    filter: brightness(1.5);
-  }
-}
-
-@keyframes lowHpWarning {
-  0%, 100% {
-    opacity: 1;
-    filter: brightness(1);
-  }
-  50% {
-    opacity: 0.6;
-    filter: brightness(1.3);
-  }
-}
-
-.plant {
-  animation: plantIdle 2s ease-in-out infinite;
-}
-
-.zombie {
-  animation: zombieWalk 3s ease-in-out infinite;
-}
-
-.plant.attacking {
-  animation: attackAnimation 0.5s ease-out;
-}
-
-.zombie.attacking {
-  animation: zombieAttack 0.6s ease-out;
-}
-
-.damaged {
-  animation: damageAnimation 0.5s ease-out;
-}
-
-@keyframes plantIdle {
-  0%, 100% {
-    transform: scale(1) rotate(0deg);
-  }
-  50% {
-    transform: scale(1.05) rotate(-2deg);
-  }
-}
-
-@keyframes zombieWalk {
-  0%, 100% {
-    transform: translateX(0) rotate(0deg);
-  }
-  50% {
-    transform: translateX(-10px) rotate(3deg);
-  }
-}
-
-@keyframes attackAnimation {
-  0% {
-    transform: scale(1);
-  }
-  50% {
-    transform: scale(1.3) translateX(20px);
-  }
-  100% {
-    transform: scale(1);
-  }
-}
-
-@keyframes zombieAttack {
-  0% {
-    transform: scale(1) translateX(0) rotate(0deg);
-  }
-  30% {
-    transform: scale(1.2) translateX(-30px) rotate(-5deg);
-  }
-  50% {
-    transform: scale(1.3) translateX(-35px) rotate(-8deg);
-  }
-  70% {
-    transform: scale(1.2) translateX(-20px) rotate(-3deg);
-  }
-  100% {
-    transform: scale(1) translateX(0) rotate(0deg);
-  }
-}
-
-@keyframes damageAnimation {
-  0%, 100% {
-    transform: translateX(0);
-    filter: drop-shadow(0 4px 8px rgba(0, 0, 0, 0.2));
+    transform: translate(-50%, 0);
   }
   25% {
-    transform: translateX(-10px);
-    filter: drop-shadow(0 4px 8px rgba(239, 68, 68, 0.6));
+    transform: translate(calc(-50% - 10px), 0);
   }
   75% {
-    transform: translateX(10px);
-    filter: drop-shadow(0 4px 8px rgba(239, 68, 68, 0.6));
+    transform: translate(calc(-50% + 10px), 0);
   }
 }
 
-.projectile {
-  position: absolute;
-  font-size: 2rem;
-  animation: shootProjectile 0.6s linear;
-  z-index: 3;
-}
-
-@keyframes shootProjectile {
-  from {
-    left: 20%;
+@keyframes questionPop {
+  0% {
+    transform: scale(0.95);
+    opacity: 0.3;
+  }
+  100% {
+    transform: scale(1);
     opacity: 1;
   }
-  to {
-    left: 80%;
-    opacity: 0;
-  }
 }
 
-@media (max-width: 1024px) {
-  .panel {
-    grid-template-columns: 1fr;
-    gap: 24px;
+@media (max-width: 960px) {
+  .padGrid {
+    grid-template-columns: repeat(3, minmax(64px, 1fr));
   }
 
-  .rightSection {
-    position: static;
+  .padWide {
+    grid-column: span 3;
   }
 
-  .battleField {
-    min-height: 240px;
+  .timerOrb {
+    width: clamp(120px, 22vw, 160px);
   }
 
-  .character {
-    font-size: 4.5rem;
+  .topBar,
+  .energyPanel,
+  .stage,
+  .bottomPanel {
+    width: 100%;
   }
 }
 
 @media (max-width: 640px) {
-  .panel {
-    gap: 20px;
+  .wrapper {
+    padding-bottom: 180px;
   }
 
-  .leftSection, .rightSection {
-    gap: 20px;
+  .topBar {
+    flex-direction: column;
+    text-align: center;
   }
 
-  .questionText {
-    font-size: 2rem;
-  }
-  
-  .numButton {
-    padding: 16px;
-    font-size: 1.5rem;
+  .levelMeta {
+    flex-direction: column;
+    align-items: center;
   }
 
-  .character {
-    font-size: 3.5rem;
+  .levelProgress {
+    width: 100%;
   }
 
-  .battleField {
-    min-height: 200px;
-    padding: 24px 16px 16px;
+  .questionPanel {
+    min-height: 280px;
   }
 
-  .hpBar {
-    width: 60px;
-    height: 10px;
-  }
-
-  .answerForm input {
-    padding: 16px 20px;
-    font-size: 1.3rem;
-  }
-
-  .statsArea {
-    padding: 20px;
-    gap: 16px;
-  }
-
-  .timer {
-    font-size: 1.3rem;
-    padding: 12px;
+  .padGrid {
+    gap: 12px;
   }
 }

--- a/src/styles/ResultPage.module.css
+++ b/src/styles/ResultPage.module.css
@@ -1,214 +1,202 @@
-.card {
-  max-width: 700px;
-  margin: 0 auto;
+.wrapper {
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: clamp(32px, 6vw, 64px) clamp(16px, 5vw, 80px);
+  background: radial-gradient(circle at top, rgba(255, 237, 213, 0.8), rgba(254, 215, 170, 0.55));
+}
+
+.board {
+  width: min(960px, 100%);
+  padding: clamp(32px, 4vw, 48px);
+  border-radius: 36px;
   display: grid;
-  gap: 28px;
-  text-align: center;
-  padding: 32px;
+  gap: clamp(20px, 3vw, 32px);
   position: relative;
   overflow: hidden;
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.95), rgba(255, 247, 237, 0.92));
+  border: 3px solid rgba(249, 115, 22, 0.28);
+  box-shadow: 0 32px 60px rgba(234, 88, 12, 0.18);
 }
 
-.card.victory {
-  background: linear-gradient(135deg, rgba(16, 185, 129, 0.15), rgba(52, 211, 153, 0.1));
-  border-color: rgba(16, 185, 129, 0.4);
-  animation: victoryPulse 2s ease-in-out;
+.board::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 20% 20%, rgba(254, 215, 170, 0.4), transparent 55%),
+    radial-gradient(circle at 80% 15%, rgba(253, 186, 116, 0.3), transparent 60%);
+  opacity: 0.65;
+  pointer-events: none;
 }
 
-.card.defeat {
-  background: linear-gradient(135deg, rgba(239, 68, 68, 0.15), rgba(220, 38, 38, 0.1));
-  border-color: rgba(239, 68, 68, 0.4);
-  animation: defeatShake 0.6s ease;
+.victory {
+  border-color: rgba(16, 185, 129, 0.45);
+  box-shadow: 0 32px 64px rgba(34, 197, 94, 0.25);
 }
 
-@keyframes victoryPulse {
-  0%, 100% {
-    transform: scale(1);
-    box-shadow: 0 10px 35px rgba(16, 185, 129, 0.2);
-  }
-  50% {
-    transform: scale(1.02);
-    box-shadow: 0 15px 45px rgba(16, 185, 129, 0.4);
-  }
+.defeat {
+  border-color: rgba(239, 68, 68, 0.45);
+  box-shadow: 0 32px 64px rgba(239, 68, 68, 0.22);
 }
 
-@keyframes defeatShake {
-  0%, 100% {
-    transform: translateX(0);
-  }
-  20%, 60% {
-    transform: translateX(-10px);
-  }
-  40%, 80% {
-    transform: translateX(10px);
-  }
-}
-
-.resultHeader {
+.moodSection {
+  display: flex;
+  align-items: center;
+  gap: clamp(16px, 3vw, 32px);
   position: relative;
   z-index: 2;
 }
 
-.victoryBanner {
-  animation: bannerSlideDown 0.6s ease-out;
+.moodIcon {
+  font-size: clamp(4rem, 8vw, 6rem);
+  filter: drop-shadow(0 12px 24px rgba(249, 115, 22, 0.25));
 }
 
-.defeatBanner {
-  animation: bannerSlideDown 0.6s ease-out;
-}
-
-@keyframes bannerSlideDown {
-  from {
-    opacity: 0;
-    transform: translateY(-50px) scale(0.9);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0) scale(1);
-  }
-}
-
-.trophy {
-  font-size: 6rem;
-  animation: trophyBounce 1s ease-in-out infinite alternate;
-  filter: drop-shadow(0 8px 16px rgba(16, 185, 129, 0.4));
-}
-
-@keyframes trophyBounce {
-  0% {
-    transform: translateY(0) rotate(-5deg);
-  }
-  100% {
-    transform: translateY(-20px) rotate(5deg);
-  }
-}
-
-.defeatIcon {
-  font-size: 6rem;
-  animation: defeatDrop 0.8s ease-out;
-  filter: drop-shadow(0 8px 16px rgba(239, 68, 68, 0.3));
-}
-
-@keyframes defeatDrop {
-  0% {
-    transform: translateY(-100px) rotate(0deg);
-    opacity: 0;
-  }
-  50% {
-    transform: translateY(10px) rotate(-10deg);
-    opacity: 1;
-  }
-  65% {
-    transform: translateY(-5px) rotate(5deg);
-  }
-  80% {
-    transform: translateY(2px) rotate(-2deg);
-  }
-  100% {
-    transform: translateY(0) rotate(0deg);
-  }
-}
-
-.victoryTitle {
-  font-size: 2.5rem;
-  margin: 16px 0 8px;
-  background: linear-gradient(90deg, #10b981, #34d399);
-  -webkit-background-clip: text;
-  background-clip: text;
-  -webkit-text-fill-color: transparent;
-  font-weight: 800;
-  animation: titleGlow 1.5s ease-in-out infinite;
-}
-
-.defeatTitle {
-  font-size: 2.5rem;
-  margin: 16px 0 8px;
-  background: linear-gradient(90deg, #ef4444, #dc2626);
-  -webkit-background-clip: text;
-  background-clip: text;
-  -webkit-text-fill-color: transparent;
-  font-weight: 800;
-}
-
-@keyframes titleGlow {
-  0%, 100% {
-    filter: drop-shadow(0 0 8px rgba(16, 185, 129, 0.3));
-  }
-  50% {
-    filter: drop-shadow(0 0 16px rgba(16, 185, 129, 0.6));
-  }
-}
-
-.victorySubtitle, .defeatSubtitle {
-  font-size: 1.1rem;
+.moodTitle {
+  margin: 0;
+  font-size: clamp(2.2rem, 4vw, 2.8rem);
+  font-weight: 900;
   color: #7c2d12;
+}
+
+.moodSubtitle {
+  margin: 6px 0 0;
+  font-size: clamp(1.05rem, 2.4vw, 1.3rem);
   font-weight: 600;
-  margin-bottom: 8px;
+  color: #c2410c;
 }
 
-.levelName {
-  font-size: 1.5rem;
-  color: #9a3412;
+.encouragement {
+  margin: 0;
+  font-size: clamp(1.05rem, 2.4vw, 1.3rem);
   font-weight: 700;
-}
-
-.summary {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-  gap: 16px;
-}
-
-.summary div {
-  padding: 20px;
+  color: #fb923c;
+  background: rgba(254, 215, 170, 0.6);
   border-radius: 18px;
-  background: linear-gradient(135deg, rgba(254, 215, 170, 0.6), rgba(253, 186, 116, 0.4));
+  padding: 12px 18px;
+  text-align: center;
+  box-shadow: inset 0 0 0 2px rgba(249, 115, 22, 0.25);
+  z-index: 2;
+}
+
+.scoreCard {
+  position: relative;
+  display: grid;
+  gap: clamp(18px, 2.6vw, 28px);
+  padding: clamp(22px, 3vw, 32px);
+  border-radius: 28px;
+  background: linear-gradient(135deg, rgba(254, 215, 170, 0.55), rgba(253, 186, 116, 0.45));
   border: 2px solid rgba(249, 115, 22, 0.3);
-  transition: all 0.3s ease;
-  animation: summaryFadeIn 0.6s ease-out backwards;
+  z-index: 2;
 }
 
-.summary div:nth-child(1) {
-  animation-delay: 0.1s;
-}
-
-.summary div:nth-child(2) {
-  animation-delay: 0.2s;
-}
-
-.summary div:nth-child(3) {
-  animation-delay: 0.3s;
-}
-
-.summary div:nth-child(4) {
-  animation-delay: 0.4s;
-}
-
-@keyframes summaryFadeIn {
-  from {
-    opacity: 0;
-    transform: translateY(20px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-.summary div:hover {
-  transform: translateY(-4px) scale(1.05);
-  box-shadow: 0 8px 20px rgba(249, 115, 22, 0.3);
-}
-
-.summary p {
-  font-size: 1.8rem;
-  font-weight: 800;
-  margin-top: 10px;
+.levelBadge {
+  align-self: start;
+  justify-self: start;
+  padding: 10px 18px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.85);
   color: #9a3412;
+  font-weight: 800;
+  font-size: 1.05rem;
+  box-shadow: 0 10px 24px rgba(249, 115, 22, 0.2);
+}
+
+.statGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: clamp(12px, 2.2vw, 18px);
+}
+
+.statGrid div {
+  padding: 16px 18px;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 12px 30px rgba(249, 115, 22, 0.16);
+  text-align: center;
+}
+
+.statLabel {
+  display: block;
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: #9a3412;
+  margin-bottom: 6px;
+}
+
+.statValue {
+  font-size: clamp(1.6rem, 3vw, 2rem);
+  font-weight: 900;
+  color: #7c2d12;
+}
+
+.progressCard {
+  display: grid;
+  gap: 12px;
+}
+
+.progressInfo {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-weight: 700;
+  color: #7c2d12;
+}
+
+.progressTrack {
+  position: relative;
+  height: 16px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.75);
+  overflow: hidden;
+}
+
+.progressFill {
+  position: absolute;
+  inset: 0;
+  width: var(--progress);
+  max-width: 100%;
+  background: linear-gradient(135deg, #f97316, #fb7185);
+  border-radius: inherit;
+  transition: width 0.4s ease;
 }
 
 .actions {
+  position: relative;
+  z-index: 2;
   display: flex;
-  justify-content: center;
-  gap: 16px;
   flex-wrap: wrap;
+  justify-content: center;
+  gap: clamp(12px, 2.4vw, 20px);
+}
+
+.actions .btn,
+.actions .btn.secondary {
+  min-width: clamp(160px, 20vw, 220px);
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+@media (max-width: 720px) {
+  .wrapper {
+    padding: 32px 16px 80px;
+  }
+
+  .board {
+    padding: 28px 20px 36px;
+  }
+
+  .moodSection {
+    flex-direction: column;
+    text-align: center;
+  }
+
+  .levelBadge {
+    justify-self: center;
+  }
+
+  .statGrid {
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  }
 }


### PR DESCRIPTION
## Summary
- redesign the play page with a single-screen battle layout including top status, energy meters, centered question panel, and keypad
- refresh tablet-focused styling with gradient backdrops, animated feedback, and sticky bottom progress/actions
- rework the result page into a game-style defeat/victory board with mood messaging, progress bar, and expanded actions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e264f9384083338530c2a834648336