### PR TITLE
Enhance attack animations and wrong answer feedback

### DIFF
--- a/src/routes/PlayPage.tsx
+++ b/src/routes/PlayPage.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, FormEvent, useCallback, useEffect, useMemo, useState } from 'react';
+import { CSSProperties, FormEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useGame } from '../context/GameContext';
 import { Game } from '../lib/engine';
@@ -37,11 +37,14 @@ export const PlayPage = () => {
   const [playerDamaged, setPlayerDamaged] = useState(false);
   const [showStars, setShowStars] = useState(false);
   const [encouragingMsg, setEncouragingMsg] = useState('');
-  const [showBullet, setShowBullet] = useState(false);
-  const [showZombieBullet, setShowZombieBullet] = useState(false);
   const [bullets, setBullets] = useState<number[]>([]); // 多个子弹
   const [zombieBullets, setZombieBullets] = useState<number[]>([]); // 多个僵尸子弹
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [wrongAnswers, setWrongAnswers] = useState<
+    Array<{ id: number; question: string; userAnswer: string; correctAnswer?: string }>
+  >([]);
+  const lastQuestionRef = useRef<Question | null>(null);
+  const lastAnswerRef = useRef('');
   const playSound = useFeedbackSound(settings.audio);
 
   const handleNumberClick = useCallback(
@@ -63,6 +66,7 @@ export const PlayPage = () => {
   const handleSubmit = useCallback(() => {
     if (!answer.trim() || state !== 'playing' || isSubmitting) return;
     setIsSubmitting(true);
+    lastAnswerRef.current = answer;
     Game.submit(answer);
     setFeedback(null);
   }, [answer, state, isSubmitting]);
@@ -109,6 +113,7 @@ export const PlayPage = () => {
     const unsubState = Game.on('statechange', ({ state: nextState }) => setState(nextState));
     const unsubQuestion = Game.on('question', (next) => {
       setQuestion(next);
+      lastQuestionRef.current = next;
       // Don't clear answer here - wait for user to see result
       setFeedback(null); // Clear feedback when moving to next question
     });
@@ -149,7 +154,19 @@ export const PlayPage = () => {
         }, 1200);
       } else {
         setZombieAttacking(true);
-        
+
+        setWrongAnswers((prev) => {
+          const currentQuestion = lastQuestionRef.current;
+          const newItem = {
+            id: Date.now(),
+            question: currentQuestion?.text ?? '未知题目',
+            userAnswer: lastAnswerRef.current.trim() ? lastAnswerRef.current : '未作答',
+            correctAnswer: fb.expected
+          };
+          const next = [newItem, ...prev];
+          return next.slice(0, 6);
+        });
+
         // 连续发射3个僵尸子弹
         [0, 1, 2].forEach((i) => {
           setTimeout(() => {
@@ -180,6 +197,9 @@ export const PlayPage = () => {
       navigate('/result');
     });
 
+    setWrongAnswers([]);
+    lastQuestionRef.current = null;
+    lastAnswerRef.current = '';
     Game.init(level);
     Game.start();
     setError(null);
@@ -278,6 +298,22 @@ export const PlayPage = () => {
     return `还有 ${remaining} 题，继续战斗！`;
   }, [answeredQuestions, totalQuestions, snapshot, monsterHpPercent, playerHpPercent]);
 
+  const questionPanelClass = [
+    'glass-card',
+    styles.questionPanel,
+    feedback && feedback.correct ? styles.questionPanelCorrect : '',
+    feedback && !feedback.correct ? styles.questionPanelWrong : ''
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  const answerInputClass = [
+    answer ? styles.hasValue : '',
+    feedback && !feedback.correct ? styles.answerError : ''
+  ]
+    .filter(Boolean)
+    .join(' ');
+
   return (
     <div className={`fade-in ${styles.wrapper}`}>
       {/* 顶部状态区：关卡名 + 进度 + 倒计时 */}
@@ -349,7 +385,7 @@ export const PlayPage = () => {
 
       {/* 主区：题目(左) + 输入区(右) */}
       <main className={styles.stage}>
-        <div className={`glass-card ${styles.questionPanel}`}>
+        <div className={questionPanelClass}>
           {showStars && <div className={styles.starBurst} aria-hidden="true" />}
           <div className={styles.questionHeader}>
             <span className={styles.questionIndex}>第 {currentQuestion || 1} 题</span>
@@ -397,6 +433,23 @@ export const PlayPage = () => {
           )}
         </div>
 
+        {wrongAnswers.length > 0 && (
+          <aside className={styles.wrongList}>
+            <div className={styles.wrongListHeader}>❌ 错题清单</div>
+            <ul className={styles.wrongListBody}>
+              {wrongAnswers.map((item) => (
+                <li key={item.id} className={styles.wrongListItem}>
+                  <div className={styles.wrongQuestion}>{item.question}</div>
+                  <div className={styles.wrongAnswers}>
+                    <span className={styles.wrongUser}>你的答案：{item.userAnswer}</span>
+                    <span className={styles.wrongCorrect}>正确答案：{item.correctAnswer ?? '未知'}</span>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </aside>
+        )}
+
         <div className={styles.inputArea}>
           <div className={`glass-card ${styles.answerPanel}`}>
             <label className={styles.answerLabel}>你的答案</label>
@@ -405,7 +458,7 @@ export const PlayPage = () => {
                 value={answer}
                 placeholder="请输入答案"
                 readOnly
-                className={answer ? styles.hasValue : ''}
+                className={answerInputClass || undefined}
               />
             </div>
           </div>

--- a/src/styles/PlayPage.module.css
+++ b/src/styles/PlayPage.module.css
@@ -115,6 +115,10 @@
   align-items: center;
   gap: clamp(20px, 3vw, 40px);
   padding: 0 clamp(20px, 3vw, 40px);
+  --bullet-start: 18%;
+  --bullet-end: 82%;
+  --zombie-bullet-start: 18%;
+  --zombie-bullet-end: 82%;
 }
 
 .characterWrapper {
@@ -193,26 +197,28 @@
 
 .bullet {
   position: absolute;
-  left: 8%;
+  left: var(--bullet-start);
   top: 50%;
   font-size: clamp(2rem, 4vw, 3rem);
-  animation: bulletFly 0.6s linear forwards;
+  animation: bulletFly 0.7s cubic-bezier(0.25, 0.8, 0.4, 1) forwards;
   z-index: 50;
   pointer-events: none;
-  filter: drop-shadow(0 0 10px rgba(34, 197, 94, 1)) 
+  transform: translate(-50%, -50%) scale(0.6);
+  filter: drop-shadow(0 0 10px rgba(34, 197, 94, 1))
           drop-shadow(0 0 20px rgba(34, 197, 94, 0.5))
           drop-shadow(0 4px 8px rgba(0, 0, 0, 0.3));
 }
 
 .zombieBullet {
   position: absolute;
-  right: 8%;
+  right: var(--zombie-bullet-start);
   top: 50%;
   font-size: clamp(2rem, 4vw, 3rem);
-  animation: zombieBulletFly 0.6s linear forwards;
+  animation: zombieBulletFly 0.65s cubic-bezier(0.25, 0.8, 0.4, 1) forwards;
   z-index: 50;
   pointer-events: none;
-  filter: drop-shadow(0 0 10px rgba(234, 88, 12, 1)) 
+  transform: translate(50%, -50%) scale(0.6) scaleX(-1);
+  filter: drop-shadow(0 0 10px rgba(234, 88, 12, 1))
           drop-shadow(0 0 20px rgba(234, 88, 12, 0.5))
           drop-shadow(0 4px 8px rgba(0, 0, 0, 0.3));
 }
@@ -220,7 +226,7 @@
 .comboBadge {
   position: absolute;
   top: 50%;
-  right: 15%; /* 靠近右侧（被攻击方） */
+  right: clamp(2%, 4vw, 6%); /* 靠近右侧（被攻击方） */
   transform: translateY(-50%);
   padding: 10px 20px;
   border-radius: 16px;
@@ -289,6 +295,7 @@
   gap: clamp(12px, 1.8vw, 20px);
   align-items: stretch;
   overflow: hidden;
+  padding-right: min(280px, 24vw);
 }
 
 .inputArea {
@@ -310,6 +317,17 @@
   justify-content: center;
   align-items: center;
   min-height: 0;
+}
+
+.questionPanelCorrect {
+  border-color: rgba(34, 197, 94, 0.55);
+  box-shadow: 0 16px 40px rgba(34, 197, 94, 0.25);
+}
+
+.questionPanelWrong {
+  border-color: rgba(239, 68, 68, 0.65);
+  box-shadow: 0 16px 46px rgba(239, 68, 68, 0.35);
+  animation: panelShake 0.55s ease;
 }
 
 .feedbackOverlay {
@@ -448,6 +466,12 @@
   border-color: rgba(249, 115, 22, 0.6);
   box-shadow: inset 0 4px 16px rgba(249, 115, 22, 0.22), 0 0 0 4px rgba(249, 115, 22, 0.15);
   animation: inputGlow 0.3s ease;
+}
+
+.answerError {
+  border-color: rgba(239, 68, 68, 0.75);
+  box-shadow: inset 0 4px 16px rgba(239, 68, 68, 0.28), 0 0 0 4px rgba(239, 68, 68, 0.2);
+  animation: inputShake 0.45s ease;
 }
 
 .answerDisplay input:focus {
@@ -693,6 +717,87 @@
   white-space: nowrap;
 }
 
+.wrongList {
+  position: absolute;
+  top: clamp(16px, 2vh, 28px);
+  right: clamp(16px, 2vw, 32px);
+  width: min(280px, 28vw);
+  max-height: min(60vh, 340px);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 16px 18px 14px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.95);
+  border: 2px solid rgba(239, 68, 68, 0.35);
+  box-shadow: 0 16px 40px rgba(239, 68, 68, 0.2);
+  backdrop-filter: blur(6px);
+  z-index: 6;
+}
+
+.wrongListHeader {
+  font-weight: 900;
+  font-size: clamp(1rem, 1.6vw, 1.2rem);
+  color: #b91c1c;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.wrongListBody {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.wrongListBody::-webkit-scrollbar {
+  width: 6px;
+}
+
+.wrongListBody::-webkit-scrollbar-thumb {
+  background: rgba(239, 68, 68, 0.4);
+  border-radius: 999px;
+}
+
+.wrongListItem {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px 12px;
+  border-radius: 14px;
+  background: rgba(254, 226, 226, 0.7);
+  border: 1px solid rgba(239, 68, 68, 0.35);
+  box-shadow: inset 0 2px 6px rgba(239, 68, 68, 0.15);
+}
+
+.wrongQuestion {
+  font-weight: 800;
+  color: #7f1d1d;
+  font-size: clamp(0.95rem, 1.3vw, 1.05rem);
+}
+
+.wrongAnswers {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: clamp(0.8rem, 1.1vw, 0.9rem);
+  color: #b91c1c;
+}
+
+.wrongUser {
+  font-weight: 700;
+}
+
+.wrongCorrect {
+  font-weight: 600;
+  color: #7c2d12;
+}
+
 @keyframes timerPulse {
   0%, 100% {
     transform: scale(1);
@@ -716,47 +821,45 @@
 
 @keyframes bulletFly {
   0% {
-    left: 8%;
-    opacity: 1;
-    transform: translateY(-50%) scale(0.6);
+    left: var(--bullet-start);
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(0.6);
   }
-  10% {
-    left: 15%;
+  15% {
     opacity: 1;
-    transform: translateY(-50%) scale(0.8);
+    transform: translate(-50%, -55%) scale(0.8);
   }
   85% {
-    left: 88%;
+    left: calc(var(--bullet-end) - 2%);
     opacity: 1;
-    transform: translateY(-50%) scale(1);
+    transform: translate(-50%, -48%) scale(1.05);
   }
   100% {
-    left: 92%;
+    left: var(--bullet-end);
     opacity: 0;
-    transform: translateY(-50%) scale(1.3);
+    transform: translate(-50%, -50%) scale(1.2);
   }
 }
 
 @keyframes zombieBulletFly {
   0% {
-    right: 8%;
-    opacity: 1;
-    transform: translateY(-50%) scale(0.6) scaleX(-1);
+    right: var(--zombie-bullet-start);
+    opacity: 0;
+    transform: translate(50%, -50%) scale(0.6) scaleX(-1);
   }
-  10% {
-    right: 15%;
+  15% {
     opacity: 1;
-    transform: translateY(-50%) scale(0.8) scaleX(-1);
+    transform: translate(50%, -55%) scale(0.8) scaleX(-1);
   }
   85% {
-    right: 88%;
+    right: calc(var(--zombie-bullet-end) - 2%);
     opacity: 1;
-    transform: translateY(-50%) scale(1) scaleX(-1);
+    transform: translate(50%, -48%) scale(1.05) scaleX(-1);
   }
   100% {
-    right: 92%;
+    right: var(--zombie-bullet-end);
     opacity: 0;
-    transform: translateY(-50%) scale(1.3) scaleX(-1);
+    transform: translate(50%, -50%) scale(1.2) scaleX(-1);
   }
 }
 
@@ -875,6 +978,42 @@
   }
 }
 
+@keyframes panelShake {
+  0%, 100% {
+    transform: translate(0, 0);
+  }
+  20% {
+    transform: translate(-10px, -2px);
+  }
+  40% {
+    transform: translate(8px, 2px);
+  }
+  60% {
+    transform: translate(-6px, 1px);
+  }
+  80% {
+    transform: translate(4px, -1px);
+  }
+}
+
+@keyframes inputShake {
+  0%, 100% {
+    transform: scale(1);
+  }
+  20% {
+    transform: scale(1.02) translateX(-6px);
+  }
+  40% {
+    transform: scale(1.03) translateX(6px);
+  }
+  60% {
+    transform: scale(1.02) translateX(-4px);
+  }
+  80% {
+    transform: scale(1.01) translateX(4px);
+  }
+}
+
 @keyframes questionSlideIn {
   0% {
     transform: translateX(-30px) scale(0.9);
@@ -893,6 +1032,7 @@
   /* Tablet landscape optimization */
   .stage {
     grid-template-columns: 1.3fr 1fr;
+    padding-right: min(220px, 22vw);
   }
   
   .questionText {
@@ -909,6 +1049,7 @@
     grid-template-columns: 1fr;
     grid-template-rows: 1fr auto;
     gap: clamp(10px, 1.5vh, 14px);
+    padding-right: 0;
   }
 
   .inputArea {
@@ -934,6 +1075,23 @@
 
   .battleRow {
     gap: clamp(12px, 2vw, 20px);
+    --bullet-start: 22%;
+    --bullet-end: 78%;
+    --zombie-bullet-start: 22%;
+    --zombie-bullet-end: 78%;
+  }
+
+  .wrongList {
+    position: static;
+    width: 100%;
+    max-width: none;
+    max-height: none;
+    margin-top: 8px;
+    order: 5;
+  }
+
+  .wrongListBody {
+    max-height: none;
   }
 
   .characterIcon {
@@ -987,6 +1145,10 @@
   .battleRow {
     flex-direction: row;
     gap: 20px;
+    --bullet-start: 25%;
+    --bullet-end: 75%;
+    --zombie-bullet-start: 25%;
+    --zombie-bullet-end: 75%;
   }
 
   .characterWrapper {
@@ -999,6 +1161,10 @@
     left: auto;
     transform: none;
     margin: 8px 0;
+  }
+
+  .wrongList {
+    padding: 14px 16px;
   }
 
   .questionPanel {


### PR DESCRIPTION
## Summary
- animate plant and zombie projectiles from left-to-right and reposition the combo badge to avoid covering the enemy
- highlight incorrect submissions with shake effects and input styling for clearer negative feedback
- collect recent wrong answers and surface them in a floating checklist so players can review mistakes during play

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2a3deed1083338c66e3045ea22d3e