### PR TITLE
Improve projectile animation lifecycle

### DIFF
--- a/src/hooks/useProjectileAnimations.ts
+++ b/src/hooks/useProjectileAnimations.ts
@@ -1,0 +1,129 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+type TimeoutHandle = ReturnType<typeof setTimeout>;
+
+type ProjectileKind = 'plant' | 'zombie';
+
+type SpawnTimerRecord = {
+  handle: TimeoutHandle;
+  kind: ProjectileKind;
+};
+
+type CleanupTimerRecord = {
+  handle: TimeoutHandle;
+  kind: ProjectileKind;
+};
+
+const createProjectileId = () => Date.now() + Math.random();
+
+const removeProjectile = (ids: number[], id: number) => ids.filter((item) => item !== id);
+
+export const useProjectileAnimations = () => {
+  const [plantProjectiles, setPlantProjectiles] = useState<number[]>([]);
+  const [zombieProjectiles, setZombieProjectiles] = useState<number[]>([]);
+
+  const spawnTimers = useRef<SpawnTimerRecord[]>([]);
+  const cleanupTimers = useRef<Map<number, CleanupTimerRecord>>(new Map());
+
+  const clearTimersByKind = useCallback((kind?: ProjectileKind) => {
+    spawnTimers.current = spawnTimers.current.filter((record) => {
+      if (!kind || record.kind === kind) {
+        clearTimeout(record.handle);
+        return false;
+      }
+      return true;
+    });
+
+    cleanupTimers.current.forEach((record, id) => {
+      if (!kind || record.kind === kind) {
+        clearTimeout(record.handle);
+        cleanupTimers.current.delete(id);
+      }
+    });
+  }, []);
+
+  const scheduleProjectile = useCallback(
+    (kind: ProjectileKind, index: number, interval: number, lifespan: number) => {
+      const spawnTimer = setTimeout(() => {
+        spawnTimers.current = spawnTimers.current.filter((record) => record.handle !== spawnTimer);
+
+        const id = createProjectileId();
+        if (kind === 'plant') {
+          setPlantProjectiles((prev) => [...prev, id]);
+        } else {
+          setZombieProjectiles((prev) => [...prev, id]);
+        }
+
+        const cleanupTimer = setTimeout(() => {
+          cleanupTimers.current.delete(id);
+          if (kind === 'plant') {
+            setPlantProjectiles((prev) => removeProjectile(prev, id));
+          } else {
+            setZombieProjectiles((prev) => removeProjectile(prev, id));
+          }
+        }, lifespan);
+
+        cleanupTimers.current.set(id, { handle: cleanupTimer, kind });
+      }, index * interval);
+
+      spawnTimers.current.push({ handle: spawnTimer, kind });
+    },
+    []
+  );
+
+  const fireBurst = useCallback(
+    (kind: ProjectileKind, count: number, interval: number, lifespan: number) => {
+      for (let i = 0; i < count; i += 1) {
+        scheduleProjectile(kind, i, interval, lifespan);
+      }
+    },
+    [scheduleProjectile]
+  );
+
+  const firePlantBurst = useCallback(
+    (count = 5, interval = 200, lifespan = 1200) => {
+      fireBurst('plant', count, interval, lifespan);
+    },
+    [fireBurst]
+  );
+
+  const fireZombieBurst = useCallback(
+    (count = 4, interval = 180, lifespan = 1000) => {
+      fireBurst('zombie', count, interval, lifespan);
+    },
+    [fireBurst]
+  );
+
+  const clearPlantProjectiles = useCallback(() => {
+    clearTimersByKind('plant');
+    setPlantProjectiles([]);
+  }, [clearTimersByKind]);
+
+  const clearZombieProjectiles = useCallback(() => {
+    clearTimersByKind('zombie');
+    setZombieProjectiles([]);
+  }, [clearTimersByKind]);
+
+  const resetProjectiles = useCallback(() => {
+    clearTimersByKind();
+    setPlantProjectiles([]);
+    setZombieProjectiles([]);
+  }, [clearTimersByKind]);
+
+  useEffect(() => {
+    return () => {
+      clearTimersByKind();
+    };
+  }, [clearTimersByKind]);
+
+  return {
+    plantProjectiles,
+    zombieProjectiles,
+    firePlantBurst,
+    fireZombieBurst,
+    clearPlantProjectiles,
+    clearZombieProjectiles,
+    resetProjectiles,
+  };
+};
+

--- a/src/routes/PlayPage.tsx
+++ b/src/routes/PlayPage.tsx
@@ -6,6 +6,7 @@ import { findLevel } from '../lib/levels';
 import { formatTime } from '../lib/utils';
 import { useFeedbackSound } from '../lib/sound';
 import { GameResult, GameSnapshot, Question } from '../lib/types';
+import { useProjectileAnimations } from '../hooks/useProjectileAnimations';
 import styles from '../styles/PlayPage.module.css';
 
 const encouragingMessages = [
@@ -37,10 +38,14 @@ export const PlayPage = () => {
   const [playerDamaged, setPlayerDamaged] = useState(false);
   const [showStars, setShowStars] = useState(false);
   const [encouragingMsg, setEncouragingMsg] = useState('');
-  const [showBullet, setShowBullet] = useState(false);
-  const [showZombieBullet, setShowZombieBullet] = useState(false);
-  const [bullets, setBullets] = useState<number[]>([]); // 多个子弹
-  const [zombieBullets, setZombieBullets] = useState<number[]>([]); // 多个僵尸子弹
+  const {
+    plantProjectiles,
+    zombieProjectiles,
+    firePlantBurst,
+    fireZombieBurst,
+    clearPlantProjectiles,
+    clearZombieProjectiles,
+  } = useProjectileAnimations();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errorListOpen, setErrorListOpen] = useState(false);
   const playSound = useFeedbackSound(settings.audio);
@@ -131,41 +136,31 @@ export const PlayPage = () => {
         setPlantAttacking(true);
         setShowStars(true);
         
-        // 连续发射5个子弹，慢慢飞
-        [0, 1, 2, 3, 4].forEach((i) => {
-          setTimeout(() => {
-            setBullets((prev) => [...prev, Date.now() + i]);
-          }, i * 200); // 每200ms发射一个
-        });
-        
+        firePlantBurst();
+
         setTimeout(() => {
           setZombieDamaged(true);
         }, 600);
-        
+
         setTimeout(() => {
           setPlantAttacking(false);
           setZombieDamaged(false);
           setShowStars(false);
-          setBullets([]);
+          clearPlantProjectiles();
         }, 2000);
       } else {
         setZombieAttacking(true);
-        
-        // 连续发射4个僵尸子弹
-        [0, 1, 2, 3].forEach((i) => {
-          setTimeout(() => {
-            setZombieBullets((prev) => [...prev, Date.now() + i]);
-          }, i * 180); // 每180ms发射一个
-        });
-        
+
+        fireZombieBurst();
+
         setTimeout(() => {
           setPlayerDamaged(true);
         }, 500);
-        
+
         setTimeout(() => {
           setZombieAttacking(false);
           setPlayerDamaged(false);
-          setZombieBullets([]);
+          clearZombieProjectiles();
         }, 1200);
       }
     });
@@ -373,10 +368,10 @@ export const PlayPage = () => {
       {/* 战斗区：角色 + 血条 + 连击 */}
       <section className={`glass-card ${styles.battleZone}`}>
         {/* 子弹层 - 在battleRow之外 */}
-        {bullets.map((id) => (
+        {plantProjectiles.map((id) => (
           <div key={id} className={styles.bullet}>🟢</div>
         ))}
-        {zombieBullets.map((id) => (
+        {zombieProjectiles.map((id) => (
           <div key={id} className={styles.zombieBullet}>🟤</div>
         ))}
         


### PR DESCRIPTION
## Summary
- refactor PlayPage projectile spawning to use a dedicated projectile animation hook and ensure bullet bursts always render
- add reusable hook to manage projectile timer cleanup and per-type resets

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2b4c459408333939a3b24d9c703c2